### PR TITLE
Create feature matrix without using pivot table.

### DIFF
--- a/ProteinCartography/foldseek_clustering.py
+++ b/ProteinCartography/foldseek_clustering.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 from collections import defaultdict
+import csv
 import pandas as pd
 import subprocess
 import os
@@ -229,14 +230,13 @@ def get_line_for_protid(protid_and_targets: tuple, targets: set):
         protid_and_targets (tuple): the first entry is a protid and the second entry is a target to score dictionary.
         targets (set): A set of all targets seen in the data set. This allows setting 0.0 as fillna(0.0) did with pandas.
     Return:
-        A string that is a single line in the similarity matrix with formatting so it can be directly written to a file.
+        A list with the protid as the first element and then scores for each target.
     """
     protid, targets_to_scores = protid_and_targets
     scores = []
     for target in targets:
         scores.append(targets_to_scores.get(target, "0.0"))
-    line = "\t".join([protid] + scores)
-    return f"{line}\n"
+    return [protid] + scores
 
 
 def pivot_foldseek_results(input_file: str, output_file: str):
@@ -252,12 +252,14 @@ def pivot_foldseek_results(input_file: str, output_file: str):
     """
     entries, targets = reading_data(input_file)
 
-    with open(output_file, "w") as fh:
-        header = "\t".join(["protid"] + list(targets))
-        fh.write(f"{header}\n")
+    with open(output_file, "w", newline='') as fh:
+        csv_writer = csv.writer(fh, delimiter='\t')
+
+        header = ["protid"] + list(targets)
+        csv_writer.writerow(header)
 
         for entry in sorted(entries.items()):
-            fh.write(get_line_for_protid(entry, targets))
+            csv_writer.writerow(get_line_for_protid(entry, targets))
 
 
 # run this if called from the interpreter


### PR DESCRIPTION
This PR updates the code in `foldseek_clustering.py` to no longer use pandas pivot table feature to generate the similarity matrix.

Some notes:

- I am using a static value of 100 for the chunksize when working in parallel. This value did a good job of keeping the serializing overhead down and the workers processing pretty consistently, but it's not currently adjustable which might be desired.
- This will default to using all of the available cores on the machine it's running on. This is settable but obviously since it's new the rest of the pipeline doesn't set any specific value. I think this is ok for a snakemake workflow as you usually want to maximally use resources.
- The `pivot_foldseek_results` no longer returns the data frame at the end. I searched the code and didn't see anywhere that the return value was being used so I think that is ok, but let me know if that change will interfere with anything. Note that by not returning the data frame a large amount of memory is never used as it's a large data frame.
- The ordering of the lines and columns of the similarity matrix might differ but the content should be the same.

Resolves Arcadia-Science/ProteinCartography#49 
