### PR TITLE
Add in exponential backoff of API calls.

### DIFF
--- a/ProteinCartography/__init__.py
+++ b/ProteinCartography/__init__.py
@@ -1,9 +1,10 @@
-__all__ = ["aggregate_features",
-           "aggregate_lists", 
+__all__ = ["api_utils",
+           "aggregate_features",
+           "aggregate_lists",
            "calculate_concordance",
            "cluster_similarity",
            "dim_reduction",
-           "esmfold_apiquery", 
+           "esmfold_apiquery",
            "extract_blasthits",
            "extract_foldseekhits",
            "extract_input_distances",
@@ -19,6 +20,7 @@ __all__ = ["aggregate_features",
            "rescue_mapping",
            "run_blast"]
 
+from .api_utils import *
 from .aggregate_features import *
 from .aggregate_foldseek_fraction_seq_identity import *
 from .aggregate_lists import *

--- a/ProteinCartography/api_utils.py
+++ b/ProteinCartography/api_utils.py
@@ -1,0 +1,58 @@
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+from bioservices import UniProt
+
+
+USER_AGENT_HEADER = {"User-Agent": "ProteinCartography/0.4 (Arcadia Science) python-requests/2.0.1"}
+
+
+def session_with_retry():
+    """
+    This will return a requests Session with `DefaultExpBackoffRetry` set for the retry strategy,
+    giving back a session with exponential backoff.
+    """
+    session = Session()
+    retry  = DefaultExpBackoffRetry()
+    session.headers.update(USER_AGENT_HEADER)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
+
+
+class DefaultExpBackoffRetry(Retry):
+    """
+    This class extends urllib3's `Retry` class. It sets defaults that seem to work well for the API
+    calls used by the pipeline. This will give requests with the following waits: [4, 8, 16, 32, 64]
+    seconds between attempts of a failing request.
+
+    Note that if you provide an argument by position and there is a kwds value,
+    either by user of default, an error will be raised by Python.
+    """
+    def __init__(self, *args, **kwds):
+        defaults = {
+            "total": 5,
+            "read": 5,
+            "connect": 5,
+            "backoff_factor": 2,
+            "status_forcelist": (500, 502, 503, 504),
+            "allowed_methods": frozenset({'GET', 'PUT', 'POST'}),
+        }
+
+        # Update kwds to default values if not already provided.
+        for key, value in defaults.items():
+            kwds.setdefault(key, value)
+
+        super().__init__(*args, **kwds)
+
+
+class UniProtWithExpBackoff(UniProt):
+    """
+    Specialize the UniProt class to set the MAX_RETRIES to be a DefaultExpBackoffRetry
+    object.
+    """
+    def __init__(self, *args, **kwargs):
+        u = super().__init__(*args, **kwargs)
+        u.services.settings.MAX_RETRIES = DefaultExpBackoffRetry()

--- a/ProteinCartography/api_utils.py
+++ b/ProteinCartography/api_utils.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry

--- a/ProteinCartography/esmfold_apiquery.py
+++ b/ProteinCartography/esmfold_apiquery.py
@@ -2,7 +2,9 @@
 import sys
 import os
 import argparse
-from requests import post
+
+from api_utils import session_with_retry
+
 
 ### NOTES
 # ESMFold API example from website:
@@ -15,10 +17,6 @@ __all__ = ["post_esmfold_apiquery", "esmfold_apiquery"]
 
 # set acceptable fasta format suffixes
 FASTA_FORMATS = ["fa", "fna", "fasta", "faa", "ffa"]
-
-REQUESTS_HEADER = {
-    "User-Agent": "ProteinCartography/0.4 (Arcadia Science) python-requests/2.0.1",
-}
 
 
 # parse command line arguments
@@ -48,10 +46,9 @@ def post_esmfold_apiquery(fasta: str):
     Args:
         fasta (str): string of valid amino acids for query.
     """
-    result = post(
+    result = session_with_retry().post(
         "https://api.esmatlas.com/foldSequence/v1/pdb/",
         data=fasta,
-        headers=REQUESTS_HEADER,
     )
     if result.status_code == 200:
         return result.text

--- a/ProteinCartography/fetch_accession.py
+++ b/ProteinCartography/fetch_accession.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python
-from bioservices import UniProt
 import argparse
 import os
-import subprocess
 from pathlib import Path
+import subprocess
+
+from api_utils import UniProtWithExpBackoff, USER_AGENT_HEADER
+
 
 # only import these functions when using import *
 __all__ = ["fetch_fasta", "fetch_pdb"]
-
-
-REQUESTS_HEADER_FLAG = (
-    "'ProteinCartography/0.4 (Arcadia Science) python-requests/2.0.1'"
-)
 
 
 # parse command line arguments
@@ -46,7 +43,7 @@ def fetch_fasta(accession: str, output_dir: str):
         accession (str): a valid UniprotKB accession.
         output_dir (str): path to the output directory. File will be saved as "{output_dir}/{accession}.fasta".
     """
-    u = UniProt()
+    u = UniProtWithExpBackoff()
     output_path = Path(output_dir) / (accession + ".fasta")
 
     if not os.path.exists(output_path):
@@ -67,8 +64,9 @@ def fetch_pdb(accession: str, output_dir: str):
     source = "https://alphafold.ebi.ac.uk/files/AF-{}-F1-model_v4.pdb".format(accession)
 
     if not os.path.exists(output_path):
+        user_agent = USER_AGENT_HEADER["User-Agent"]
         subprocess.run(
-            ["curl", "-JLo", output_path, source, "--user-agent", REQUESTS_HEADER_FLAG],
+            ["curl", "-JLo", output_path, source, "--user-agent", f"'{user_agent}'"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )

--- a/ProteinCartography/fetch_uniprot_metadata.py
+++ b/ProteinCartography/fetch_uniprot_metadata.py
@@ -5,10 +5,7 @@ import numpy as np
 import os
 import re
 
-from api_utils import (
-    session_with_retry,
-    UniProtWithExpBackoff,
-)
+from api_utils import session_with_retry, UniProtWithExpBackoff
 
 
 # only import these functions when using import *

--- a/ProteinCartography/fetch_uniprot_metadata.py
+++ b/ProteinCartography/fetch_uniprot_metadata.py
@@ -2,11 +2,14 @@
 import argparse
 import pandas as pd
 import numpy as np
-from bioservices import UniProt
 import os
 import re
-import requests
-from requests.adapters import HTTPAdapter, Retry
+
+from api_utils import (
+    session_with_retry,
+    UniProtWithExpBackoff,
+)
+
 
 # only import these functions when using import *
 __all__ = ["query_uniprot_bioservices", "query_uniprot_rest"]
@@ -40,10 +43,6 @@ OTHER_FIELDS_DICT = {
 DEFAULT_FIELDS_DICT = REQUIRED_FIELDS_DICT | OTHER_FIELDS_DICT
 REQUIRED_FIELDS = list(REQUIRED_FIELDS_DICT.values())
 DEFAULT_FIELDS = list(DEFAULT_FIELDS_DICT.values())
-
-REQUESTS_HEADER = {
-    "User-Agent": "ProteinCartography/0.4 (Arcadia Science) python-requests/2.0.1",
-}
 
 
 # parse command line arguments
@@ -96,7 +95,7 @@ def query_uniprot_bioservices(
 
     # perform ID mapping using bioservices UniProt
     # should probably do this differently in the future because it often results in weird memory leaks
-    u = UniProt()
+    u = UniProtWithExpBackoff()
     results = u.mapping("UniProtKB_AC-ID", "UniProtKB", query=" ".join(id_list))
 
     # read the results as a normalized json
@@ -150,12 +149,7 @@ def query_uniprot_rest(
     # Define regular expression pattern to extract the next URL from the response headers
     re_next_link = re.compile(r'<(.+)>; rel="next"')
 
-    # Configure the retry behavior for the HTTP requests
-    retries = Retry(total=5, backoff_factor=0.25, status_forcelist=[500, 502, 503, 504])
-
-    # Create a session object and mount the HTTPAdapter with retry settings
-    session = requests.Session()
-    session.mount("https://", HTTPAdapter(max_retries=retries))
+    session = session_with_retry()
 
     def get_next_link(headers):
         # Extract the next URL from the "Link" header if present
@@ -167,7 +161,7 @@ def query_uniprot_rest(
     def get_batch(batch_url):
         # Generator function to fetch data in batches
         while batch_url:
-            response = session.get(batch_url, headers=REQUESTS_HEADER)
+            response = session.get(batch_url)
             response.raise_for_status()
             total = response.headers["x-total-results"]
             yield response, total


### PR DESCRIPTION
This adds in exponential back off for API calls (except for the curl call). Let me know if this approach makes sense. I also tried to make this as specific to the currently problem as opposed to making it easy to reuse in any use case. It would be easy to update if that is needed, but I like to keep things as simple as possible until they need to become more complex, let me know if you disagree on that.

I have run through specific scripts that were failing often in addition to running the demo pipeline and both seem to be handling failures better. For the `esmfold` API sometimes there are quite a few failures before the request succeeds so looking into moving away from the API would be good to both speed up that part as well as make it more reliable, but this does help quite a bit from my test runs.