### PR TITLE
Fix ESMFold API requests - disable SSL to avoid certificate errors

### DIFF
--- a/ProteinCartography/api_utils.py
+++ b/ProteinCartography/api_utils.py
@@ -6,7 +6,7 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from tests import artifact_generation_utils, mocks
-import ssl
+
 
 __all__ = ["session_with_retry", "DefaultExpBackoffRetry", "UniProtWithExpBackoff"]
 
@@ -28,12 +28,6 @@ if os.environ.get("PROTEINCARTOGRAPHY_WAS_CALLED_BY_PYTEST") == "true":
 # it should *not* be set in production.
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_LOG_API_REQUESTS") == "true":
     HTTPAdapter = artifact_generation_utils.HTTPAdapterWithLogging  # noqa F811
-
-
-
-#We need to disable SSL due to a certificate error with the ESM Atlas API
-#See https://github.com/facebookresearch/esm/discussions/627
-ssl._create_default_https_context = ssl._create_unverified_context
 
 
 def session_with_retry():

--- a/ProteinCartography/api_utils.py
+++ b/ProteinCartography/api_utils.py
@@ -6,6 +6,7 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from tests import artifact_generation_utils, mocks
+import ssl
 
 __all__ = ["session_with_retry", "DefaultExpBackoffRetry", "UniProtWithExpBackoff"]
 
@@ -27,6 +28,12 @@ if os.environ.get("PROTEINCARTOGRAPHY_WAS_CALLED_BY_PYTEST") == "true":
 # it should *not* be set in production.
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_LOG_API_REQUESTS") == "true":
     HTTPAdapter = artifact_generation_utils.HTTPAdapterWithLogging  # noqa F811
+
+
+
+#We need to disable SSL due to a certificate error with the ESM Atlas API
+#See https://github.com/facebookresearch/esm/discussions/627
+ssl._create_default_https_context = ssl._create_unverified_context
 
 
 def session_with_retry():

--- a/ProteinCartography/api_utils.py
+++ b/ProteinCartography/api_utils.py
@@ -7,7 +7,6 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from tests import artifact_generation_utils, mocks
 
-
 __all__ = ["session_with_retry", "DefaultExpBackoffRetry", "UniProtWithExpBackoff"]
 
 USER_AGENT_HEADER = {"User-Agent": "ProteinCartography/0.4 (Arcadia Science) python-requests/2.0.1"}

--- a/ProteinCartography/esmfold_apiquery.py
+++ b/ProteinCartography/esmfold_apiquery.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import sys
+import warnings
 
 # depends on api_utils.py
 from api_utils import session_with_retry
@@ -53,7 +54,7 @@ def post_esmfold_apiquery(fasta: str):
     """
     result = session_with_retry().post(
         "https://api.esmatlas.com/foldSequence/v1/pdb/",
-        data=fasta,
+        data=fasta, verify=False
     )
     if result.status_code == 200:
         return result.text
@@ -123,7 +124,12 @@ def main():
 
     input_file = args.input
     output_file = args.output
-    esmfold_apiquery(input_file, output_file)
+
+    #Ignore warnings when we make the ESMFold API request
+    #We're disabling SSL which `requests` will otherwise warn us about
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        esmfold_apiquery(input_file, output_file)
 
 
 # check if called from interpreter

--- a/ProteinCartography/esmfold_apiquery.py
+++ b/ProteinCartography/esmfold_apiquery.py
@@ -54,7 +54,8 @@ def post_esmfold_apiquery(fasta: str):
         fasta (str): string of valid amino acids for query.
     """
     # Here we're making the request with verify=False to disable SSL
-    # This may be a security concern, but is (hopefully) temporary until the ESM Atlas SSL certificates are fixed
+    # This may be a security concern, but is (hopefully)
+    # temporary until the ESM Atlas SSL certificates are fixed
     result = session_with_retry().post(
         "https://api.esmatlas.com/foldSequence/v1/pdb/", data=fasta, verify=False
     )

--- a/ProteinCartography/esmfold_apiquery.py
+++ b/ProteinCartography/esmfold_apiquery.py
@@ -7,6 +7,7 @@ import warnings
 # depends on api_utils.py
 from api_utils import session_with_retry
 from Bio import SeqIO
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 ### NOTES
 # ESMFold API example from website:
@@ -52,9 +53,10 @@ def post_esmfold_apiquery(fasta: str):
     Args:
         fasta (str): string of valid amino acids for query.
     """
+    # Here we're making the request with verify=False to disable SSL
+    # This may be a security concern, but is (hopefully) temporary until the ESM Atlas SSL certificates are fixed
     result = session_with_retry().post(
-        "https://api.esmatlas.com/foldSequence/v1/pdb/",
-        data=fasta, verify=False
+        "https://api.esmatlas.com/foldSequence/v1/pdb/", data=fasta, verify=False
     )
     if result.status_code == 200:
         return result.text
@@ -125,10 +127,10 @@ def main():
     input_file = args.input
     output_file = args.output
 
-    #Ignore warnings when we make the ESMFold API request
-    #We're disabling SSL which `requests` will otherwise warn us about
+    # Ignore warnings when we make the ESMFold API request
+    # We're disabling SSL which `requests` will otherwise warn us about
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter("ignore", category=InsecureRequestWarning)
         esmfold_apiquery(input_file, output_file)
 
 


### PR DESCRIPTION
Fixes #80  - now ESMFold API requests work and don't fail SSL certificate checks.

`ProteinCartography/esmfold_apiquery.py` has been updated to disable SSL when making the API request, and suppress the warnings from the `requests` module.

Tested using `python ProteinCartography/esmfold_apiquery.py -i 2PK8_monomer.fasta -o ./2PK8_esmfold.pdb` - outputs a PDB file as expected.