### PR TITLE
Ensure user-provided PDBs are used for clustering

### DIFF
--- a/ProteinCartography/filter_uniprot_hits.py
+++ b/ProteinCartography/filter_uniprot_hits.py
@@ -30,6 +30,11 @@ def parse_args():
         default="0",
         help="maximum protein length of proteins to keep. If set to 0, no upper limit is applied.",
     )
+    parser.add_argument(
+        "--excluded-protids",
+        nargs="*",
+        help="a list of protids to exclude from the results",
+    )
     args = parser.parse_args()
 
     return args
@@ -42,6 +47,7 @@ def filter_results(
     filter_fragment=True,
     min_length=0,
     max_length=0,
+    excluded_protids=None,
 ):
     """
     Takes an input uniprot_features.tsv file and filters the results based on fragment status,
@@ -78,6 +84,11 @@ def filter_results(
     if max_length > 0:
         filtered_df = filtered_df[filtered_df["Length"].astype(int) < max_length]
 
+    if excluded_protids is None:
+        excluded_protids = []
+
+    filtered_df = filtered_df[~filtered_df["protid"].isin(excluded_protids)]
+
     with open(output_file, "w+") as f:
         f.writelines([protid + "\n" for protid in filtered_df["protid"]])
 
@@ -88,6 +99,7 @@ def main():
     args = parse_args()
     input_file = args.input
     output_file = args.output
+    excluded_protids = args.excluded_protids
 
     try:
         min_length = int(args.min_length)
@@ -98,7 +110,13 @@ def main():
     except (TypeError, ValueError):
         max_length = 0
 
-    filter_results(input_file, output_file, min_length=min_length, max_length=max_length)
+    filter_results(
+        input_file,
+        output_file,
+        min_length=min_length,
+        max_length=max_length,
+        excluded_protids=excluded_protids,
+    )
 
 
 if __name__ == "__main__":

--- a/Snakefile
+++ b/Snakefile
@@ -125,7 +125,7 @@ rule make_pdb:
     input:
         cds=input_dir / "{protid}.fasta",
     output:
-        pdb=input_dir / "{protid}.pdb",
+        pdb=pdb_download_dir / "{protid}.pdb",
     benchmark:
         output_dir / benchmarks_dir / "{protid}.make_pdb.txt"
     conda:
@@ -148,6 +148,11 @@ rule copy_pdb:
         """
         cp {input} {output}
         """
+
+
+# first try to copy any user-provided PDB files from the input directory;
+# if they don't exist, generate them using make_pdb
+ruleorder: copy_pdb > make_pdb
 
 
 rule run_blast:

--- a/Snakefile
+++ b/Snakefile
@@ -353,7 +353,7 @@ rule filter_uniprot_hits:
         "envs/pandas.yml"
     shell:
         """
-        python ProteinCartography/filter_uniprot_hits.py -i {input} -o {output} -m {params.min_length} -M {params.max_length}
+        python ProteinCartography/filter_uniprot_hits.py -i {input} -o {output} -m {params.min_length} -M {params.max_length} --excluded-protids {PROTID}
         """
 
 


### PR DESCRIPTION
## Overview
This PR makes two changes to fix bugs that may prevent user-provided PDB files from being used for clustering:
- it makes `copy_pdb` and `make_pdb` ambiguous rules with precedence given to `copy_pdb`; this prevents `make_pdb` from being called if a user-provided PDB is present for a given input protid
- it removes the input protids from the list of protids for which to download PDBs from alphafold so that either `copy_pdb` or `make_pdb` is always called for all of the input protids

This should (hopefully) address #82. 

This behavior is not currently covered by automated testing, but I tested manually that `copy_pdb` is called when a PDB is present in the input directory, whether or not its protid was among the aggregated hits for which alphafold PDBs are downloaded. 

## PR checklist
- [x] Tag the issue(s) or milestones this PR fixes (e.g. `Fixes #123, Resolves #456`).
- [x] Describe the changes you've made.
- [x] Describe any tests you have conducted to confirm that your changes behave as expected.
- [x] If you've added new software dependencies, make sure that those dependencies are included in the appropriate `conda` environments.
- [x] If you've added new functionality, make sure that the documentation is updated accordingly.
- [x] If you encountered bugs or features that you won't address, but should be addressed eventually, create new issues for them.
