### PR TITLE
Update AlphaFold URL

### DIFF
--- a/ProteinCartography/aggregate_foldseek_fraction_seq_identity.py
+++ b/ProteinCartography/aggregate_foldseek_fraction_seq_identity.py
@@ -64,12 +64,10 @@ def aggregate_foldseek_fident(input_files: list, output_file: str, protid: str) 
 
     # extract the model ID from the results file
     dummy_df["modelid"] = dummy_df["target"].str.split(" ", expand=True)[0]
-    dummy_df = dummy_df[dummy_df["modelid"].str.contains("-F1-model_v4")]
+    dummy_df = dummy_df[dummy_df["modelid"].str.contains("-F1-model")]
 
     # get the uniprot ID out from that target
-    dummy_df["protid"] = dummy_df["modelid"].apply(
-        lambda x: re.findall("AF-(.*)-F1-model_v4", x)[0]
-    )
+    dummy_df["protid"] = dummy_df["modelid"].apply(lambda x: re.findall("AF-(.*)-F1-model", x)[0])
 
     # collect only the relevant columns
     results_df = dummy_df[constants.FOLDSEEK_OUT_COLUMN_NAMES]

--- a/ProteinCartography/extract_foldseek_hits.py
+++ b/ProteinCartography/extract_foldseek_hits.py
@@ -69,14 +69,14 @@ def extract_foldseekhits(
 
         # extract only models that contain AF model string
         # this will need to be changed in the future
-        file_df = file_df[file_df["modelid"].str.contains("-F1-model_v4")]
+        file_df = file_df[file_df["modelid"].str.contains("-F1-model")]
 
         # filter by evalue
         file_df = file_df[file_df["evalue"] < evalue]
 
         # get the uniprot ID out from that target
         file_df["uniprotid"] = file_df["modelid"].apply(
-            lambda x: re.findall("AF-(.*)-F1-model_v4", x)[0]
+            lambda x: re.findall("AF-(.*)-F1-model", x)[0]
         )
 
         # if it's the first results file, fill the dummy_df

--- a/ProteinCartography/fetch_accession.py
+++ b/ProteinCartography/fetch_accession.py
@@ -66,7 +66,7 @@ def fetch_pdb(accession: str, output_dir: str, session=None):
         session (requests.Session, optional): the requests session to use for the request.
     """
     output_path = Path(output_dir) / f"{accession}.pdb"
-    source = f"https://alphafold.ebi.ac.uk/files/AF-{accession}-F1-model_v4.pdb"
+    source = f"https://alphafold.ebi.ac.uk/files/AF-{accession}-F1-model_v6.pdb"
 
     if session is None:
         session = session_with_retry()

--- a/ProteinCartography/tests/artifact_generation_utils.py
+++ b/ProteinCartography/tests/artifact_generation_utils.py
@@ -34,12 +34,12 @@ class HTTPAdapterWithLogging(HTTPAdapter):
         output_filepath = self._log_dirpath / f"{request.method}__{sanitized_url[:100]}"
 
         if stream:
-            # consume the streamed content and write it to a file
+            # Consume the streamed content and write it to a file.
             content = b"".join(response.iter_content(chunk_size=128))
             with open(output_filepath, "wb") as file:
                 file.write(content)
 
-            # this allows the response content to be streamed again
+            # This allows the response content to be streamed again.
             response._content = content
 
         else:

--- a/ProteinCartography/tests/mocks.py
+++ b/ProteinCartography/tests/mocks.py
@@ -7,7 +7,7 @@ import file_utils
 import requests
 
 # TODO (KC): eliminate the hard-coded dataset name ("actin"),
-# which needs to match the dataset name used in the `stage_inputs` pytest fixture
+# which needs to match the dataset name used in the `stage_inputs` pytest fixture.
 ARTIFACTS_DIRPATH = (
     file_utils.find_repo_dirpath()
     / "ProteinCartography"
@@ -23,7 +23,7 @@ API_RESPONSE_ARTIFACTS_DIRPATH = ARTIFACTS_DIRPATH / "api_response_content"
 def mock_run_blast():
     """
     Mock the `run_blast.run_blast` method to prevent it from calling `blastp`
-    by copying a mock blastresults.tsv file to the output directory
+    by copying a mock blastresults.tsv file to the output directory.
     """
 
     result = mock.Mock(spec=subprocess.CompletedProcess)
@@ -40,7 +40,7 @@ def mock_run_blast():
 def mock_requests_session_request():
     """
     Mock the `request` method of `requests.Session` to return mock responses
-    (constructed in `mock_response` below) instead of making real API calls
+    (constructed in `mock_response` below) instead of making real API calls.
     """
     patch = mock.patch("requests.Session.request", side_effect=mock_response)
     # we start the patch but never stop it, because we want to mock all requests
@@ -50,9 +50,9 @@ def mock_requests_session_request():
 
 def mock_bioservices_uniprot_search():
     """
-    Mock the `search` method of `bioservices.UniProt` to prevent it from making real API calls
+    Mock the `search` method of `bioservices.UniProt` to prevent it from making real API calls.
     Note: because `UniProt.search` queries the UniProtKB REST API, this patch can reuse the response
-    constructed in `mock_uniprotkb_rest_api_responses`
+    constructed in `mock_uniprotkb_rest_api_responses`.
     """
     patch = mock.patch(
         "api_utils.UniProtWithExpBackoff.search",
@@ -63,9 +63,9 @@ def mock_bioservices_uniprot_search():
 
 def mock_bioservices_uniprot_mapping():
     """
-    Mock the `mapping` method of `bioservices.UniProt` to prevent it from making real API calls
+    Mock the `mapping` method of `bioservices.UniProt` to prevent it from making real API calls.
     Note: because `UniProt.mapping` queries the UniProt ID-Mapping API,
-    this patch can reuse the response constructed in `mock_uniprot_id_mapping_api_responses`
+    this patch can reuse the response constructed in `mock_uniprot_id_mapping_api_responses`.
     """
     response = mock_uniprot_id_mapping_api_responses("GET", "stream/0")
 
@@ -80,24 +80,24 @@ def mock_bioservices_uniprot_mapping():
 
 def mock_response(method, url, **_):
     """
-    return a mock response for a given method and url
+    Return a mock response for a given method and url.
     """
 
     print(f"Mocking the response to: {method} {url}")
 
-    # requests to the UniProt ID Mapping REST API
+    # Requests to the UniProt ID Mapping REST API.
     if url.startswith("https://rest.uniprot.org/idmapping"):
         return mock_uniprot_id_mapping_api_responses(method, url)
 
-    # requests to the Foldseek API
+    # Requests to the Foldseek API.
     elif url.startswith("https://search.foldseek.com/api"):
         return mock_foldseek_api_responses(method, url)
 
-    # requests to the UniProtKB REST API
+    # Requests to the UniProtKB REST API.
     elif url.startswith("https://rest.uniprot.org/uniprotkb/search"):
         return mock_uniprotkb_rest_api_responses()
 
-    # requests to the alphafold API
+    # Requests to the alphafold API.
     elif url.startswith("https://alphafold.ebi.ac.uk/files"):
         return mock_alphafold_files_api_responses(url)
 
@@ -107,8 +107,8 @@ def mock_response(method, url, **_):
 
 def mock_uniprot_id_mapping_api_responses(method, url):
     """
-    mock the responses to calls made to the UniProt ID Mapping REST API
-    (these are made by `map_refseqids.map_refseqids_rest`)
+    Mock the responses to calls made to the UniProt ID Mapping REST API
+    (these are made by `map_refseqids.map_refseqids_rest`).
     """
     mock_response = mock.Mock(spec=requests.Response)
     mock_response.status_code = 200
@@ -116,18 +116,18 @@ def mock_uniprot_id_mapping_api_responses(method, url):
     job_id = "0"
     payload = {}
 
-    # the initial POST request
+    # The initial POST request.
     if method == "POST" and url.endswith("run"):
         payload = {"jobId": job_id}
 
-    # the polling request
-    # ('success' is defined by the presence of a 'results' key in the response)
+    # The subsequent polling requests.
+    # ('success' is defined by the presence of a 'results' key in the response.)
     elif url.endswith(f"status/{job_id}"):
         payload = {"results": "some-results"}
 
-    # the request to get the results
-    # note: this payload is manually aggregated from the results of real API calls
-    # to both of the default databases ["EMBL-GenBank-DDBJ_CDS", "RefSeq_Protein"]
+    # The request to get the results.
+    # Note: this payload is manually aggregated from the results of real API calls
+    # to both of the default databases ("EMBL-GenBank-DDBJ_CDS" and "RefSeq_Protein").
     elif url.endswith(f"stream/{job_id}"):
         payload = {
             "results": [
@@ -157,7 +157,7 @@ def mock_uniprot_id_mapping_api_responses(method, url):
 
 def mock_foldseek_api_responses(method, url):
     """
-    mock the responses to calls made to the Foldseek API (by `foldseek_apiquery`)
+    Mock the responses to calls made to the Foldseek API (by `foldseek_apiquery`).
 
     Note: this makes no attempt to parse the POST request body;
     it just returns the response from a real API call.
@@ -166,24 +166,24 @@ def mock_foldseek_api_responses(method, url):
     mock_response = mock.Mock(spec=requests.Response)
     mock_response.status_code = 200
 
-    # the initial POST request
+    # The initial POST request.
     job_id = "0"
     if method == "POST" and url.endswith("api/ticket"):
         mock_response.json.return_value = {"id": job_id, "status": "COMPLETE"}
 
-    # the polling request
-    # (this request is made even if the response to the initial POST request is "COMPLETE")
+    # The polling request.
+    # (This request is made even if the response to the initial POST request is "COMPLETE".)
     elif url.endswith(f"api/ticket/{job_id}"):
         mock_response.json.return_value = {"id": job_id, "status": "COMPLETE"}
 
-    # the request to get the results
+    # The request to get the results.
     elif url.endswith(f"api/result/download/{job_id}"):
         with open(
             API_RESPONSE_ARTIFACTS_DIRPATH / "search.foldseek.com_api_result_download", "rb"
         ) as file:
             content = file.read()
 
-        # this allows the response content to be streamed
+        # This allows the response content to be streamed.
         mock_response.iter_content.return_value = [content]
 
     else:
@@ -194,8 +194,8 @@ def mock_foldseek_api_responses(method, url):
 
 def mock_uniprotkb_rest_api_responses():
     """
-    mock the response to calls made to the UniProtKB REST API
-    (these are made by `fetch_uniprot_metadata.query_uniprot`)
+    Mock the response to calls made to the UniProtKB REST API
+    (these are made by `fetch_uniprot_metadata.query_uniprot`).
 
     Note: this makes no attempt to parse the query string; it just returns a manually curated
     response from a real API call.
@@ -204,8 +204,8 @@ def mock_uniprotkb_rest_api_responses():
     mock_response = mock.Mock(spec=requests.Response)
     mock_response.status_code = 200
 
-    # define an empty header, specifically one without a 'Link' key
-    # to prevent `fetch_uniprot_metadata.query_uniprot` from requesting a second batch of results
+    # Define an empty header, specifically one without a 'Link' key
+    # to prevent `fetch_uniprot_metadata.query_uniprot` from requesting a second batch of results.
     mock_response.headers = {}
 
     with open(
@@ -218,11 +218,11 @@ def mock_uniprotkb_rest_api_responses():
 
 def mock_alphafold_files_api_responses(url):
     """
-    mock the response to calls made to the AlphaFold API to download PDB files
+    Mock the response to calls made to the AlphaFold API to download PDB files.
     """
 
-    # parse the accession from the url
-    result = re.findall(r"AF-([A-Z0-9]+)-F1-model_v4\.pdb", url)
+    # Parse the accession from the url.
+    result = re.findall(r"AF-([A-Z0-9]+)-F1-model_v6\.pdb", url)
     if result is None:
         raise ValueError("Unexpected url: {url}")
     accession = result[0]
@@ -230,6 +230,9 @@ def mock_alphafold_files_api_responses(url):
     mock_response = mock.Mock(spec=requests.Response)
     mock_response.status_code = 200
 
+    # The AlphaFold URL requests v6 files, but the test artifacts contain v4 files.
+    # Because we can safely use the "old" v4 files for testing purposes,
+    # we point to the v4 files here.
     artifact_filepath = (
         API_RESPONSE_ARTIFACTS_DIRPATH / f"alphafold.ebi.ac.uk_files_AF-{accession}-F1-model_v4.pdb"
     )

--- a/ProteinCartography/tests/test_pipeline_in_cluster_mode.py
+++ b/ProteinCartography/tests/test_pipeline_in_cluster_mode.py
@@ -10,7 +10,7 @@ import yaml
 @pytest.fixture
 def config_filepath(tmp_path):
     """
-    Generate a config file for testing the pipeline in "cluster" mode
+    Generate a config file for testing the pipeline in "cluster" mode.
     """
     config = {
         "mode": "cluster",
@@ -32,12 +32,12 @@ def config_filepath(tmp_path):
 @pytest.fixture
 def stage_inputs(integration_test_artifacts_dirpath, config_filepath):
     """
-    Create the input directory and the PDB files for the pipeline in "cluster" mode
+    Create the input directory and the PDB files for the pipeline in "cluster" mode.
     """
     with open(config_filepath) as file:
         config = yaml.safe_load(file)
 
-    # for now, hard-code the dataset name
+    # For now, hard-code the dataset name.
     dataset_name = "actin"
     shutil.copytree(
         integration_test_artifacts_dirpath / "cluster-mode" / dataset_name / "input",
@@ -48,7 +48,7 @@ def stage_inputs(integration_test_artifacts_dirpath, config_filepath):
 @pytest.mark.usefixtures("stage_inputs")
 def test_pipeline_in_cluster_mode(repo_dirpath, config_filepath):
     """
-    Run the pipeline in "cluster" mode with the test config file
+    Run the pipeline in "cluster" mode with the test config file.
     """
 
     snakemake.snakemake(
@@ -65,7 +65,7 @@ def test_pipeline_in_cluster_mode(repo_dirpath, config_filepath):
     input_dirpath = pathlib.Path(config["input_dir"])
     output_dirpath = pathlib.Path(config["output_dir"])
 
-    # check (some of) the expected output files
+    # Check (some of) the expected output files.
     expected_output_filepaths = [
         output_dirpath / "final_results" / f"{config['analysis_name']}_{appendix}"
         for appendix in [
@@ -78,12 +78,12 @@ def test_pipeline_in_cluster_mode(repo_dirpath, config_filepath):
     for filepath in expected_output_filepaths:
         assert filepath.exists()
 
-    # check that the shape of the all-by-all similarity matrix is correct
+    # Check that the shape of the all-by-all similarity matrix is correct.
     num_structures = len(list(input_dirpath.glob("*.pdb")))
     similarity_matrix_filepath = (
         output_dirpath / "foldseek_clustering_results" / "all_by_all_tmscore_pivoted.tsv"
     )
     similarity_matrix = pd.read_csv(similarity_matrix_filepath, sep="\t")
 
-    # matrix should have one row and one column per structure (plus one column for the index)
+    # The matrix should have one row and one column per structure (plus one column for the index).
     assert similarity_matrix.shape == (num_structures, num_structures + 1)

--- a/ProteinCartography/tests/test_pipeline_in_search_mode.py
+++ b/ProteinCartography/tests/test_pipeline_in_search_mode.py
@@ -10,7 +10,7 @@ import yaml
 
 def _load_config(filepath):
     """
-    Convenience function to load a yaml config file
+    Convenience function to load a yaml config file.
     """
     with open(filepath) as file:
         config = yaml.safe_load(file)
@@ -20,7 +20,7 @@ def _load_config(filepath):
 @pytest.fixture
 def config_filepath(tmp_path):
     """
-    Generate a config file for testing the pipeline
+    Generate a config file for testing the pipeline.
     """
     config = {
         "mode": "search",
@@ -43,12 +43,12 @@ def config_filepath(tmp_path):
 @pytest.fixture
 def stage_inputs(integration_test_artifacts_dirpath, config_filepath):
     """
-    Create the input directory and input files for the pipeline
+    Create the input directory and input files for the pipeline.
     """
 
     config = _load_config(config_filepath)
 
-    # for now, hard-code the dataset name
+    # For now, hard-code the dataset name.
     dataset_name = "actin"
     shutil.copytree(
         integration_test_artifacts_dirpath / "search-mode" / dataset_name / "input",
@@ -60,27 +60,27 @@ def stage_inputs(integration_test_artifacts_dirpath, config_filepath):
 def set_env_variables(pytestconfig):
     """
     Set the env variable used to mock the API responses
-    made by the python scripts that are called by the snakemake rules
+    made by the python scripts that are called by the snakemake rules.
 
     Note: this works because the rule environments inherit their env variables from the environment
-    in which `snakemake` was called (which is this pytest python process)
+    in which `snakemake` was called (which is this pytest python process).
     """
 
-    # the names of the proteincartography-specific env variables
+    # The names of the proteincartography-specific env variables.
     should_use_mocks = "PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS"
     should_log_api_requests = "PROTEINCARTOGRAPHY_SHOULD_LOG_API_REQUESTS"
 
     if not pytestconfig.getoption("no_mocks"):
         os.environ[should_use_mocks] = "true"
 
-    # don't log API requests during the tests
+    # Don't log API requests during the tests.
     should_log_api_requests_value = os.environ.pop(should_log_api_requests, None)
 
     yield
 
     os.environ.pop(should_use_mocks, None)
 
-    # as a convenience, restore the logging env variable to its original value
+    # As a convenience, restore the logging env variable to its original value.
     if should_log_api_requests_value is not None:
         os.environ[should_log_api_requests] = should_log_api_requests_value
 
@@ -90,9 +90,8 @@ def set_env_variables(pytestconfig):
 def test_pipeline_in_search_mode_with_mocked_api_calls(repo_dirpath, config_filepath):
     """
     Run the pipeline in "search" mode with the test config file, the temporary snakefile,
-    and mocked API calls
+    and mocked API calls.
     """
-
     snakemake.snakemake(
         snakefile=(repo_dirpath / "Snakefile"),
         configfiles=[config_filepath],
@@ -104,7 +103,7 @@ def test_pipeline_in_search_mode_with_mocked_api_calls(repo_dirpath, config_file
     config = _load_config(config_filepath)
     output_dirpath = pathlib.Path(config["output_dir"])
 
-    # check (some of) the expected output files
+    # Check (some of) the expected output files.
     expected_output_filepaths = [
         output_dirpath / "final_results" / f"{config['analysis_name']}_{appendix}"
         for appendix in [
@@ -115,14 +114,14 @@ def test_pipeline_in_search_mode_with_mocked_api_calls(repo_dirpath, config_file
         ]
     ]
     for filepath in expected_output_filepaths:
-        # TODO (KC): check that the content of the files looks correct
+        # TODO (KC): Check that the content of the files looks correct.
         # (not sure we can do a literal comparison because of timestamps, umap stochasticity, etc.)
         assert filepath.exists()
 
-    # check that the shape of the all-by-all similarity matrix is correct:
+    # Check that the shape of the all-by-all similarity matrix is correct;
     # there should be 11 structures clustered by foldseek
     # (the 10 determined by the `max_structures` config param, plus the input structure),
-    # so the dataframe should have 11 rows and 12 columns (since the first column is the index)
+    # so the dataframe should have 11 rows and 12 columns (since the first column is the index).
     similarity_matrix_filepath = (
         output_dirpath / "foldseek_clustering_results" / "all_by_all_tmscore_pivoted.tsv"
     )


### PR DESCRIPTION
This PR updates the URL used to download PDB files from AlphaFold. This URL was of the form:

```py
f"https://alphafold.ebi.ac.uk/files/AF-{accession}-F1-model_v4.pdb"
```

The change here is simply to switch "v4" to "v6". This change was prompted by my observation that the pipeline was failing due to empty/invalid PDB files. I verified that the "v4" URL was indeed returning empty PDB files, and I manually inferred what I assume is the new/correct AlphaFold URL (it is as simple as changing the "v4" to "v6"). I then manually verified that the downloaded PDBs are valid and that the pipeline works. (I could not find any documentation about this change on the AlphaFold website or repo, hence the manual validation.)

This is also an attempt to address the error reported in #97 (but it's not yet clear that the error there is related).

<!--
# Arcadia-Science/ProteinCartography-private pull request

Many thanks for contributing to Arcadia-Science/ProteinCartography-private!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] Tag the issue(s) or milestones this PR fixes (e.g. `Fixes #123, Resolves #456`).
- [x] Describe the changes you've made.
- [x] Describe any tests you have conducted to confirm that your changes behave as expected.