### PR TITLE
Fixed warnings from reproducibility audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The pipeline supports two modes: **Search** and **Cluster**. Both modes are impl
 
 In this mode, the pipeline starts with a set of input proteins of interest in PDB and FASTA format and performs broad BLAST and Foldseek searches to identify hits. The pipeline aggregates all hits, downloads PDBs, and builds a map.
 
+Note: Search mode depends on live external APIs (Foldseek, BLAST, UniProt, and AlphaFold database). These services may change, experience downtime, or enforce rate limits, so results may not be fully reproducible across runs separated by significant time.
+
 ![search-mode-rulegraph](rulegraph-search-mode.png)
 
 #### Inputs
@@ -135,7 +137,7 @@ In this mode, the pipeline starts with a folder containing PDBs of interest and 
         - `output`: directory where all pipeline outputs are placed.
         - `analysis_name`: nickname for the analysis, appended to important output files.
         - `features_file`: path to features file (described below).
-        - (Optional) `keyids`: a list of one or more key `protid` corresponding to the proteins to highlight in the output plots (similar to how the input proteins are highlighted in 'search' mode). Note: if not provided, the output directory `key_protid_tmscore_results` will be empty, as will the `protein_features/key_protid_tmscore_features.tsv` file.
+        - (Optional) `keyids`: a list of one or more key `protid` corresponding to the proteins to highlight in the output plots (similar to how the input proteins are highlighted in 'search' mode). Note: if not provided, the output directory `key_protid_tmscore_results` will be empty, as will the `protein_features/key_protid_tmscore_features.tsv` file. If `keyids` is provided, the pipeline will make Foldseek API calls for each key protein, so an internet connection is still required even in cluster mode.
         - See [`config.yml`](config.yml) for additional parameters.
 - Features file with protein metadata.
     - Usually, we call this file `uniprot_features.tsv` but you can use any name.

--- a/envs/analysis.yml
+++ b/envs/analysis.yml
@@ -3,6 +3,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - python=3.9
   - leidenalg=0.9.1
   - scanpy=1.9.3
   - scikit-learn=1.2.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="ProteinCartography",
-    url="https://github.com/Arcadia-Science/ProteinCartography-private",
+    url="https://github.com/Arcadia-Science/ProteinCartography",
     author="Dennis Sun",
     author_email="dennis.sun@arcadiascience.com",
     packages=["ProteinCartography"],
@@ -16,7 +16,6 @@ setup(
         "ProteinCartography/esmfold_apiquery.py",
         "ProteinCartography/extract_blast_hits.py",
         "ProteinCartography/extract_foldseek_hits.py",
-        "ProteinCartography/extract_input_protein_distances.py",
         "ProteinCartography/fetch_accession.py",
         "ProteinCartography/foldseek_apiquery.py",
         "ProteinCartography/foldseek_clustering.py",


### PR DESCRIPTION
This PR is to address a few small changes found in a reproducibility audit. I primarily addressed these by adding additional documentation regarding API calls. None of these changes should affect the functionality of the pipeline.
1. **External API dependencies are fragile**: The pipeline depends on live Foldseek, BLAST remote, UniProt REST, and AlphaFold APIs in search mode. These are inherently non-reproducible over time (APIs may change, servers may go down, rate limits may be hit). The README partially addresses this (e.g., line 213: "Restarting Snakemake with the `--rerun-incomplete` flag usually resolves this"), but a reproducer running this months or years later may encounter failures.
2. **Cluster mode with `key_protids` still requires Foldseek API calls**: In `Snakefile` lines 586–591, `get_aggregate_features_input()` expands `aggregate_foldseek_fraction_seq_identity` and `calculate_concordance` for `KEY_PROTIDS` as a common input (not search-mode-only). This triggers the `run_foldseek` rule (a web API call) for each key_protid even in cluster mode. The README's cluster mode documentation (lines 119–168) does not mention this network requirement, which may surprise users who expect cluster mode to be fully offline.
3. Additionally, I cleaned up a couple of things in the `setup.py` file, which isn't currently used. 