### PR TITLE
Fix `pip install .` and importing package modules outside a git working tree

### DIFF
--- a/ProteinCartography/api_utils.py
+++ b/ProteinCartography/api_utils.py
@@ -5,7 +5,6 @@ from bioservices import UniProt
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-from tests import artifact_generation_utils, mocks
 
 __all__ = ["session_with_retry", "DefaultExpBackoffRetry", "UniProtWithExpBackoff"]
 
@@ -15,6 +14,8 @@ USER_AGENT_HEADER = {"User-Agent": "ProteinCartography/0.4 (Arcadia Science) pyt
 # Note: the env variable below is set by the `set_env_variables` pytest fixture during test setup;
 # it should be used only during testing and *not* in production.
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
+    from tests import mocks
+
     mocks.mock_requests_session_request()
 
 # If necessary, use the custom (and crude) `HTTPAdapterWithLogging` class in place of `HTTPAdapter`
@@ -24,6 +25,8 @@ if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
 # The env var below should only ever be set manually by the developer in a dev environment;
 # it should *not* be set in production.
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_LOG_API_REQUESTS") == "true":
+    from tests import artifact_generation_utils
+
     HTTPAdapter = artifact_generation_utils.HTTPAdapterWithLogging  # noqa F811
 
 

--- a/ProteinCartography/fetch_uniprot_metadata.py
+++ b/ProteinCartography/fetch_uniprot_metadata.py
@@ -7,11 +7,12 @@ import numpy as np
 import pandas as pd
 from api_utils import UniProtWithExpBackoff, session_with_retry
 from constants import UniProtService
-from tests import mocks
 
 # if necessary, mock the `uniprot.search` method (used by `query_uniprot`)
 # see comments in `tests.mocks` for more details
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
+    from tests import mocks
+
     mocks.mock_bioservices_uniprot_search()
 
 # only import these functions when using import *

--- a/ProteinCartography/map_refseq_ids.py
+++ b/ProteinCartography/map_refseq_ids.py
@@ -10,11 +10,12 @@ from api_utils import (
     session_with_retry,
 )
 from constants import UniProtService
-from tests import mocks
 
 # If necessary, mock the `uniprot.mapping` method (used by `map_refseqids_bioservices`).
 # See comments in `tests.mocks` for more details.
 if os.environ.get("PROTEINCARTOGRAPHY_WAS_CALLED_BY_PYTEST") == "true":
+    from tests import mocks
+
     mocks.mock_bioservices_uniprot_mapping()
 
 __all__ = ["map_refseqids_bioservices", "map_refseqids_rest"]

--- a/ProteinCartography/run_blast.py
+++ b/ProteinCartography/run_blast.py
@@ -5,11 +5,12 @@ import sys
 
 import blast_utils
 import constants
-from tests import mocks
 
 # if necessary, mock the `run_blast` method
 # see comments in `tests.mocks` for more details
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
+    from tests import mocks
+
     mocks.mock_run_blast()
 
 

--- a/ProteinCartography/tests/test_packaging.py
+++ b/ProteinCartography/tests/test_packaging.py
@@ -1,0 +1,128 @@
+"""
+Tests that the package can be installed and that its modules can be imported
+outside of a git working tree.
+
+These are unit tests and do not run the pipeline, so unlike the other tests in this
+directory they do not need network access, conda environments, or mocked API responses.
+"""
+
+import ast
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+PACKAGE_DIRPATH = pathlib.Path(__file__).parent.parent
+REPO_DIRPATH = PACKAGE_DIRPATH.parent
+SETUP_FILEPATH = REPO_DIRPATH / "setup.py"
+
+
+def get_setup_scripts() -> list:
+    """
+    Parse setup.py and return the list of filepaths in the `scripts` argument of `setup()`.
+
+    Returns:
+        The script filepaths, relative to the root of the repo.
+    """
+    tree = ast.parse(SETUP_FILEPATH.read_text())
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setup"):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "scripts":
+                return [element.value for element in keyword.value.elts]
+    raise AssertionError("Could not find a `scripts` argument in setup.py.")
+
+
+def get_module_scope_imports(filepath: pathlib.Path) -> list:
+    """
+    Return the names of the top-level packages imported at module scope in a module.
+
+    Args:
+        filepath: the module to parse.
+
+    Returns:
+        The top-level package names, for example "os" for `import os.path`.
+    """
+    module_names = []
+    for node in ast.parse(filepath.read_text()).body:
+        if isinstance(node, ast.ImportFrom):
+            module_names.append(node.module)
+        elif isinstance(node, ast.Import):
+            module_names.extend(alias.name for alias in node.names)
+    return [(name or "").split(".")[0] for name in module_names]
+
+
+def test_all_scripts_listed_in_setup_py_exist():
+    """
+    Tests that every script in `scripts` exists, because setuptools raises
+    a `FileNotFoundError` in its `build_scripts` step for scripts that do not,
+    which makes the package impossible to install.
+    """
+    missing_filepaths = [
+        filepath for filepath in get_setup_scripts() if not (REPO_DIRPATH / filepath).exists()
+    ]
+    assert not missing_filepaths, (
+        f"setup.py lists scripts that do not exist: {missing_filepaths}. "
+        "This makes `pip install .` fail during the `build_scripts` step."
+    )
+
+
+def test_no_module_imports_the_tests_package_at_module_scope():
+    """
+    Tests that no module in the package imports the `tests` package at module scope.
+
+    The `tests` package is not included in the `packages` argument of `setup()`, and importing
+    `tests.mocks` calls `find_repo_dirpath()` at import time, so importing it at module scope
+    makes the importing module unusable outside of a git working tree.
+    """
+    offending_filenames = [
+        filepath.name
+        for filepath in sorted(PACKAGE_DIRPATH.glob("*.py"))
+        if "tests" in get_module_scope_imports(filepath)
+    ]
+    assert not offending_filenames, (
+        f"these modules import the `tests` package at module scope: {offending_filenames}. "
+        "It should be imported inside the branch that uses it."
+    )
+
+
+def test_api_utils_is_importable_outside_a_git_repo(tmp_path):
+    """
+    Tests that `api_utils` can be imported from a copy of the package that is not
+    inside a git working tree, which is the case for an installed copy of the package
+    or an extracted release archive.
+    """
+    package_copy_dirpath = tmp_path / PACKAGE_DIRPATH.name
+    shutil.copytree(
+        PACKAGE_DIRPATH,
+        package_copy_dirpath,
+        ignore=shutil.ignore_patterns("integration-test-artifacts", "__pycache__"),
+    )
+
+    # `find_repo_dirpath` walks upwards, so the copy is only a valid test case if there is
+    # no git working tree above it either.
+    assert not any(
+        (dirpath / ".git").exists()
+        for dirpath in [package_copy_dirpath, *package_copy_dirpath.parents]
+    )
+
+    # `bioservices` is imported by `api_utils` but is not in the environment the tests run in,
+    # so it is stubbed out; this test is about which modules `api_utils` imports, not about
+    # what they contain.
+    (package_copy_dirpath / "bioservices.py").write_text("class UniProt:\n    pass\n")
+
+    # The mock-related env variables are unset because the mocks intentionally require
+    # the repo, so they are not expected to work outside of a git working tree.
+    env = {
+        key: value for key, value in os.environ.items() if not key.startswith("PROTEINCARTOGRAPHY_")
+    }
+    process = subprocess.run(
+        [sys.executable, "-c", "import api_utils"],
+        cwd=package_copy_dirpath,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert process.returncode == 0, process.stderr

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
         "ProteinCartography/esmfold_apiquery.py",
         "ProteinCartography/extract_blast_hits.py",
         "ProteinCartography/extract_foldseek_hits.py",
-        "ProteinCartography/extract_input_protein_distances.py",
         "ProteinCartography/fetch_accession.py",
         "ProteinCartography/foldseek_apiquery.py",
         "ProteinCartography/foldseek_clustering.py",


### PR DESCRIPTION
Two defects at `41ff35f`, both reproducible from a clean checkout.

**`pip install .` fails.** `setup.py` lists `ProteinCartography/extract_input_protein_distances.py` in `scripts`, but that file was removed in #136 (`2ed21cb`, Feb 2024) and replaced by `calculate_key_protid_tmscores.py`, which was never added to the list. setuptools raises in its `build_scripts` step, so nothing installs. `v0.5.0` is affected too — its `setup.py` still lists the file and the file isn't in that tree either.

```
error: [Errno 2] No such file or directory: 'ProteinCartography/extract_input_protein_distances.py'
```

**Four modules can't be imported outside a git working tree.** `api_utils`, `run_blast`, `map_refseq_ids` and `fetch_uniprot_metadata` each import the `tests` package at module scope, and `tests/mocks.py` calls `find_repo_dirpath()` at import time, which walks up looking for `.git`. `tests` also isn't in the `packages` argument of `setup()`, so it isn't installed alongside the package. Two of the four are themselves entries in `scripts`, and `api_utils` is imported by six other modules.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../ProteinCartography/api_utils.py", line 8, in <module>
    from tests import artifact_generation_utils, mocks
  File ".../ProteinCartography/tests/mocks.py", line 12, in <module>
    file_utils.find_repo_dirpath()
  File ".../ProteinCartography/file_utils.py", line 18, in find_repo_dirpath
    raise FileNotFoundError("Could not find the root of the local git repo.")
FileNotFoundError: Could not find the root of the local git repo.
```

The fix removes the missing `scripts` entry and moves each `tests` import inside the `if os.environ.get(...)` branch that already gates its use. With mocks or request logging enabled the behaviour is identical; with neither set — production — a module that was imported and unused simply no longer is. The mocks still require a checkout, which is right: they read fixtures out of the repo.

`ProteinCartography/tests/test_packaging.py` covers both failures and all three tests fail on `main`. They need no dependencies beyond the test environment: the import test stubs out `bioservices`, since the point is which modules `api_utils` pulls in rather than what they contain.

I wasn't able to run `make test` — it needs conda and the Snakemake rule environments, which I don't have on this machine. `ruff check` and `ruff format --check` at your pinned 0.1.6 are clean. `snakefmt --check` reports `Snakefile` would be changed, but reports the same on unmodified `main`, so it isn't from this PR and I left it alone.

This doesn't add packaging CI, so nothing stops the `scripts` list drifting out of sync again. The alternative fix for the second defect would be to make `ARTIFACTS_DIRPATH` in `tests/mocks.py` lazy so importing the module no longer needs a checkout; I went with the import guards instead because they keep the mocks' dependency on the repo explicit, but say the word if you'd prefer it the other way. `CONTRIBUTING.md` asks external contributors to open an issue first — happy to move this to one.
