### PR TITLE
Fix conda env dependency drift, add a blast stub and smoke test, and detect failed blastp calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,10 @@ jobs:
         id: cache-snakemake-conda-envs
         with:
           path: .snakemake/conda
+          # note: `restore-keys` are matched as a prefix of `key`, so they must share its prefix
+          # (this previously began with "snakemake-conda-", which never matched anything)
           key: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('envs/*.yml') }}
-          restore-keys: snakemake-conda-${{ runner.os }}--${{ runner.arch }}--
+          restore-keys: conda-${{ runner.os }}--${{ runner.arch }}--
 
       - name: Create the snakemake conda envs
         if: steps.cache-snakemake-conda-envs.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,12 @@ jobs:
         id: cache-snakemake-conda-envs
         with:
           path: .snakemake/conda
-          # note: `restore-keys` are matched as a prefix of `key`, so they must share its prefix
-          # (this previously began with "snakemake-conda-", which never matched anything)
           key: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('envs/*.yml') }}
-          restore-keys: conda-${{ runner.os }}--${{ runner.arch }}--
+          # note: there are deliberately no `restore-keys` here. A `restore-keys` match still
+          # leaves `cache-hit` false, so the step below runs anyway and begins by deleting
+          # `.snakemake/conda` -- meaning a partial match would download a stale multi-gigabyte
+          # cache only to discard it. (The `restore-keys` this replaces began with
+          # "snakemake-conda-" while the key begins with "conda-", so it never matched at all.)
 
       - name: Create the snakemake conda envs
         if: steps.cache-snakemake-conda-envs.outputs.cache-hit != 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,11 @@ We use `ruff` to lint and format our Python code. We also use snakemake’s code
 ### Testing
 Tests are found in the `ProteinCartography/tests/` directory. We use `pytest` for testing; you can run the tests locally using the command `make test`. Currently, we only have integration-like tests that run the pipeline in both 'search' and 'cluster' modes using a test dataset and test config designed to allow the pipeline run very quickly (2-3min). The tests then check that the output files are created and have the correct shape. We plan to add unit tests in the future.
 
+#### Running the smoke test
+To quickly check that the pipeline still runs all the way through, use `make smoke-test`. This runs only the 'search' mode test, which exercises every rule in the pipeline with all external calls mocked or stubbed out, and checks that the final output files are created. Note that the first run is slow, because snakemake has to build the per-rule conda envs.
+
+The one external call that is not mocked with `requests` is the call to `blastp`, because it is made in a subprocess rather than over HTTP. Instead, setting the `PROTEINCARTOGRAPHY_BLAST_STUB_RESULTS_FILEPATH` env variable to the path of a canned blast results file makes `blast_utils.run_blast` copy that file to its output path instead of calling `blastp -remote` (which takes 10-40 minutes, because it queues on NCBI's public servers). The tests set this env variable in the `set_env_variables` fixture; it should never be set in production.
+
 #### Running the tests without mocked API responses
 When the pipeline is run in 'search' mode, it makes many calls to external APIs (including Foldseek, Blast, and Alphafold). By default, these calls are mocked during testing so that the tests do not depend on external APIs; this is important to ensure test reproducibility and also helps to make the tests run quickly. However, it is important to periodically test that the pipeline also runs correctly when real API calls are made. To do this, you can run the tests without mocks using `make test-without-mocks`.
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ test:
 test-without-mocks:
 	pytest -vv -s --no-mocks
 
+# Run the whole pipeline end to end with every external call mocked or stubbed out,
+# and check that it produces its final output files. This is the fastest way to verify
+# that the pipeline still runs all the way through.
+# Note: the first run is slow, because snakemake has to build the per-rule conda envs.
+.PHONY: smoke-test
+smoke-test:
+	pytest -vv -s -m smoke .
+
 .PHONY: run-demo-workflow
 run-demo-workflow:
 	snakemake \

--- a/ProteinCartography/blast_utils.py
+++ b/ProteinCartography/blast_utils.py
@@ -1,4 +1,41 @@
+import os
+import pathlib
+import shutil
 import subprocess
+
+# If this env variable is set to the path of a canned blastp results file, `run_blast` copies that
+# file to its output path instead of calling `blastp` against the remote NCBI server.
+# This exists because the real remote blastp call queues on NCBI's public servers and takes
+# 10-40 minutes, which makes end-to-end verification of the pipeline impractical.
+# It is intended for testing only (see the `smoke-test` make target); never set it in production.
+#
+# Note: an env variable is used (rather than a CLI flag on `run_blast.py`) because the snakemake
+# rule environments inherit their env variables from the process that calls snakemake,
+# so no changes to the Snakefile or the pipeline config are needed to activate the stub.
+STUB_RESULTS_FILEPATH_ENV_VAR = "PROTEINCARTOGRAPHY_BLAST_STUB_RESULTS_FILEPATH"
+
+
+def run_blast_stub(stub_results_filepath: str, out: str):
+    """
+    Stand in for a call to `blastp` by copying a canned blastp results file to `out`.
+
+    Note: the canned file is copied verbatim, so it is not filtered by, or consistent with,
+    the query sequence or any of the blastp parameters that `run_blast` is called with.
+
+    Args:
+        stub_results_filepath (str): path of the canned blastresults.tsv file to copy.
+        out (str): path of the destination blastresults.tsv file.
+    """
+    stub_results_filepath = pathlib.Path(stub_results_filepath)
+    if not stub_results_filepath.exists():
+        raise FileNotFoundError(
+            f"The blast stub results file '{stub_results_filepath}' does not exist "
+            f"(it was set by the '{STUB_RESULTS_FILEPATH_ENV_VAR}' env variable)."
+        )
+
+    print(f"Using the stubbed blast results in '{stub_results_filepath}' instead of calling blastp")
+    shutil.copy(stub_results_filepath, out)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
 
 
 def run_blast(
@@ -14,8 +51,8 @@ def run_blast(
 
     Note: the argument names used here correspond exactly to (a subset of the) blastp CLI arguments
 
-    Note: this function is in its own module, rather than in `run_blast.py`,
-    so that it can be mocked by calling `tests.mocks.mock_run_blast` at the top of `run_blast.py`
+    Note: if the env variable named by `STUB_RESULTS_FILEPATH_ENV_VAR` is set,
+    this function copies a canned results file instead of calling `blastp` (see `run_blast_stub`).
 
     Args:
         query (str): path of input peptide FASTA file.
@@ -25,6 +62,10 @@ def run_blast(
         word_size (str): passed to blastp '-word_size'
         evalue (str): passed to blastp '-evalue'
     """
+    stub_results_filepath = os.environ.get(STUB_RESULTS_FILEPATH_ENV_VAR)
+    if stub_results_filepath:
+        return run_blast_stub(stub_results_filepath, out)
+
     database = "nr"
     result = subprocess.run(
         " ".join(

--- a/ProteinCartography/blast_utils.py
+++ b/ProteinCartography/blast_utils.py
@@ -15,6 +15,39 @@ import subprocess
 STUB_RESULTS_FILEPATH_ENV_VAR = "PROTEINCARTOGRAPHY_BLAST_STUB_RESULTS_FILEPATH"
 
 
+def blast_call_failed(result: subprocess.CompletedProcess) -> bool:
+    """
+    Determine whether a call to `blastp` failed.
+
+    The exit code alone is not sufficient: when the remote server refuses to queue a request,
+    `blastp -remote` writes an error to stderr, writes an empty results file, and nevertheless
+    exits with a status of zero. For example:
+
+        Error: [blastp] bad_request: Could not queue request: DB operation failed.
+
+    Checking only the exit code therefore treats these failures as successes, which prevents
+    the word-size backoff in `run_blast.py` from ever being attempted and defers the failure
+    to `extract_blast_hits.py`, where it appears as a misleading "no hits were returned" error.
+
+    Note: an empty results file is deliberately *not* treated as a failure here, because a query
+    that legitimately has no hits also produces one.
+
+    Args:
+        result (subprocess.CompletedProcess): the result of the call to `blastp`.
+
+    Returns:
+        True if the call failed.
+    """
+    if result.returncode != 0:
+        return True
+
+    stderr = result.stderr
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+
+    return "Error:" in (stderr or "")
+
+
 def run_blast_stub(stub_results_filepath: str, out: str):
     """
     Stand in for a call to `blastp` by copying a canned blastp results file to `out`.

--- a/ProteinCartography/run_blast.py
+++ b/ProteinCartography/run_blast.py
@@ -76,7 +76,7 @@ def main():
             word_size=word_size,
             evalue=args.evalue,
         )
-        if result.returncode == 0:
+        if not blast_utils.blast_call_failed(result):
             sys.exit(0)
         else:
             num_tries += 1

--- a/ProteinCartography/run_blast.py
+++ b/ProteinCartography/run_blast.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python
 import argparse
-import os
 import sys
 
 import blast_utils
 import constants
-
-# if necessary, mock the `run_blast` method
-# see comments in `tests.mocks` for more details
-if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
-    from tests import mocks
-
-    mocks.mock_run_blast()
 
 
 def parse_args():

--- a/ProteinCartography/tests/mocks.py
+++ b/ProteinCartography/tests/mocks.py
@@ -1,6 +1,4 @@
 import re
-import shutil
-import subprocess
 from unittest import mock
 
 import file_utils
@@ -18,23 +16,6 @@ ARTIFACTS_DIRPATH = (
 )
 
 API_RESPONSE_ARTIFACTS_DIRPATH = ARTIFACTS_DIRPATH / "api_response_content"
-
-
-def mock_run_blast():
-    """
-    Mock the `run_blast.run_blast` method to prevent it from calling `blastp`
-    by copying a mock blastresults.tsv file to the output directory.
-    """
-
-    result = mock.Mock(spec=subprocess.CompletedProcess)
-    result.returncode = 0
-
-    def side_effect(out=None, **_):
-        shutil.copy(ARTIFACTS_DIRPATH / "output" / "P60709.blastresults.tsv", out)
-        return result
-
-    patch = mock.patch("blast_utils.run_blast", side_effect=side_effect)
-    patch.start()
 
 
 def mock_requests_session_request():

--- a/ProteinCartography/tests/test_blast_utils.py
+++ b/ProteinCartography/tests/test_blast_utils.py
@@ -1,0 +1,70 @@
+"""
+Tests for detecting failed calls to `blastp`.
+
+These are unit tests and do not call `blastp`, so unlike the other tests in this
+directory they do not need network access, conda environments, or mocked API responses.
+"""
+
+import subprocess
+
+import blast_utils
+
+
+def make_result(returncode=0, stderr=b""):
+    """
+    Construct a `CompletedProcess` that stands in for the result of a call to `blastp`.
+    """
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=b"", stderr=stderr)
+
+
+def test_successful_call_did_not_fail():
+    assert not blast_utils.blast_call_failed(make_result())
+
+
+def test_nonzero_exit_code_is_a_failure():
+    assert blast_utils.blast_call_failed(make_result(returncode=1))
+
+
+def test_error_on_stderr_is_a_failure_despite_a_zero_exit_code():
+    """
+    Tests the case that motivates checking stderr at all: when the remote server refuses to
+    queue the request, `blastp -remote` reports the error but still exits with a status of zero.
+    """
+    stderr = (
+        b"Error: [blastp] bad_request: Could not queue request: DB operation failed."
+        b"(ERR:-99  )((Severe Error) DB Put Request error: sp_NewRequestEx failed)\n"
+    )
+    assert blast_utils.blast_call_failed(make_result(returncode=0, stderr=stderr))
+
+
+def test_warning_on_stderr_is_not_a_failure():
+    """
+    Tests that stderr output which is not an error does not cause a successful call
+    to be treated as a failure.
+    """
+    stderr = b"Warning: [blastp] Examining 5 or more matches is recommended\n"
+    assert not blast_utils.blast_call_failed(make_result(returncode=0, stderr=stderr))
+
+
+def test_stderr_may_be_a_string_or_none():
+    """
+    Tests that stderr is handled whether it is bytes, str, or absent, since the stub
+    and the real call do not construct it the same way.
+    """
+    assert blast_utils.blast_call_failed(make_result(stderr="Error: something went wrong"))
+    assert not blast_utils.blast_call_failed(make_result(stderr="all good"))
+    assert not blast_utils.blast_call_failed(make_result(stderr=None))
+
+
+def test_the_stub_does_not_look_like_a_failure(tmp_path):
+    """
+    Tests that the result returned by the blast stub is not mistaken for a failed call.
+    """
+    stub_results_filepath = tmp_path / "stub.tsv"
+    stub_results_filepath.write_text("qseqid\tsseqid\n")
+    out_filepath = tmp_path / "out.tsv"
+
+    result = blast_utils.run_blast_stub(str(stub_results_filepath), str(out_filepath))
+
+    assert not blast_utils.blast_call_failed(result)
+    assert out_filepath.read_text() == "qseqid\tsseqid\n"

--- a/ProteinCartography/tests/test_pipeline_in_search_mode.py
+++ b/ProteinCartography/tests/test_pipeline_in_search_mode.py
@@ -7,6 +7,8 @@ import pytest
 import snakemake
 import yaml
 
+from ProteinCartography import blast_utils
+
 
 def _load_config(filepath):
     """
@@ -57,10 +59,11 @@ def stage_inputs(integration_test_artifacts_dirpath, config_filepath):
 
 
 @pytest.fixture
-def set_env_variables(pytestconfig):
+def set_env_variables(pytestconfig, integration_test_artifacts_dirpath):
     """
-    Set the env variable used to mock the API responses
-    made by the python scripts that are called by the snakemake rules.
+    Set the env variables used to mock the API responses made by the python scripts that are
+    called by the snakemake rules, and to stub out the remote `blastp` call made by the
+    `run_blast` rule.
 
     Note: this works because the rule environments inherit their env variables from the environment
     in which `snakemake` was called (which is this pytest python process).
@@ -69,9 +72,23 @@ def set_env_variables(pytestconfig):
     # The names of the proteincartography-specific env variables.
     should_use_mocks = "PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS"
     should_log_api_requests = "PROTEINCARTOGRAPHY_SHOULD_LOG_API_REQUESTS"
+    blast_stub_env_var = blast_utils.STUB_RESULTS_FILEPATH_ENV_VAR
+
+    # The canned blastp results that the `run_blast` rule uses in place of a real remote
+    # blastp call (which takes 10-40 minutes because it queues on NCBI's public servers).
+    # For now, hard-code the dataset name, as the `stage_inputs` fixture does.
+    dataset_name = "actin"
+    stub_results_filepath = (
+        integration_test_artifacts_dirpath
+        / "search-mode"
+        / dataset_name
+        / "output"
+        / "P60709.blastresults.tsv"
+    )
 
     if not pytestconfig.getoption("no_mocks"):
         os.environ[should_use_mocks] = "true"
+        os.environ[blast_stub_env_var] = str(stub_results_filepath)
 
     # Don't log API requests during the tests.
     should_log_api_requests_value = os.environ.pop(should_log_api_requests, None)
@@ -79,26 +96,32 @@ def set_env_variables(pytestconfig):
     yield
 
     os.environ.pop(should_use_mocks, None)
+    os.environ.pop(blast_stub_env_var, None)
 
     # As a convenience, restore the logging env variable to its original value.
     if should_log_api_requests_value is not None:
         os.environ[should_log_api_requests] = should_log_api_requests_value
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures("stage_inputs")
 @pytest.mark.usefixtures("set_env_variables")
 def test_pipeline_in_search_mode_with_mocked_api_calls(repo_dirpath, config_filepath):
     """
     Run the pipeline in "search" mode with the test config file, the temporary snakefile,
-    and mocked API calls.
+    mocked API calls, and a stubbed-out call to `blastp`.
+
+    This test is marked as the pipeline's smoke test (see the `smoke-test` make target),
+    because it exercises every rule in the pipeline end to end.
     """
-    snakemake.snakemake(
+    was_successful = snakemake.snakemake(
         snakefile=(repo_dirpath / "Snakefile"),
         configfiles=[config_filepath],
         use_conda=True,
         cores=8,
         verbose=True,
     )
+    assert was_successful, "The snakemake workflow did not run to completion."
 
     config = _load_config(config_filepath)
     output_dirpath = pathlib.Path(config["output_dir"])
@@ -116,7 +139,8 @@ def test_pipeline_in_search_mode_with_mocked_api_calls(repo_dirpath, config_file
     for filepath in expected_output_filepaths:
         # TODO (KC): Check that the content of the files looks correct.
         # (not sure we can do a literal comparison because of timestamps, umap stochasticity, etc.)
-        assert filepath.exists()
+        assert filepath.exists(), f"The expected output file '{filepath}' was not created."
+        assert filepath.stat().st_size > 0, f"The output file '{filepath}' is empty."
 
     # Check that the shape of the all-by-all similarity matrix is correct;
     # there should be 11 structures clustered by foldseek

--- a/Snakefile
+++ b/Snakefile
@@ -636,7 +636,7 @@ rule plot_interactive:
         tm_scores=rules.dim_reduction.output.all_by_all_tmscores,
         features=rules.aggregate_features.output.aggregated_features,
     output:
-        html=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_aggregated_features_{{plotting_mode}}.html",
+        html=FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_aggregated_features_{plotting_mode}.html"),
     conda:
         "envs/plotting.yml"
     benchmark:
@@ -752,7 +752,7 @@ rule plot_cluster_distributions:
     input:
         features=rules.aggregate_features.output.aggregated_features,
     output:
-        svg=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_{{protid}}_distribution_analysis.svg",
+        svg=FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_{protid}_distribution_analysis.svg"),
     conda:
         "envs/plotting.yml"
     benchmark:

--- a/envs/analysis.yml
+++ b/envs/analysis.yml
@@ -10,3 +10,9 @@ dependencies:
   - pandas=2.0.1
   - numpy=1.23.5
   - nltk=3.8.1
+  # matplotlib is an indirect dependency (via scanpy) and must be pinned, because recent
+  # versions of it require numpy>=1.25 and so are incompatible with the numpy pin above.
+  # This pin matches the one in `plotting.yml`.
+  - matplotlib=3.7.1
+  # `umap-learn` imports `pkg_resources`, which setuptools removed in version 81.
+  - setuptools<81

--- a/envs/analysis.yml
+++ b/envs/analysis.yml
@@ -3,6 +3,10 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  # python is pinned to match the other environments; left unpinned, this
+  # environment resolves to whatever the newest python conda-forge has builds for
+  # (it had drifted to python 3.11 while every pinned environment was on 3.9).
+  - python=3.9.16
   - leidenalg=0.9.1
   - scanpy=1.9.3
   - scikit-learn=1.2.2
@@ -10,8 +14,11 @@ dependencies:
   - pandas=2.0.1
   - numpy=1.23.5
   - nltk=3.8.1
-  # matplotlib is an indirect dependency (via scanpy) and must be pinned, because recent
-  # versions of it require numpy>=1.25 and so are incompatible with the numpy pin above.
+  # matplotlib is an indirect dependency (via scanpy) and must be pinned. Recent versions are
+  # built against numpy 2 and raise `ImportError: Matplotlib requires numpy>=1.25` when they
+  # are imported alongside the numpy pinned above. Note that the solver installs them together
+  # quite happily, so this is not caught when the environment is built, only when it is used.
+  # More generally, an environment that pins numpy has to pin what is compiled against it.
   # This pin matches the one in `plotting.yml`.
   - matplotlib=3.7.1
   # `umap-learn` imports `pkg_resources`, which setuptools removed in version 81.

--- a/envs/cartography_test.yml
+++ b/envs/cartography_test.yml
@@ -5,7 +5,10 @@ channels:
 dependencies:
   - python=3.9.16
   - snakemake-minimal=7.25.3
-  - mamba
+  # mamba must be pinned to 1.x: snakemake 7.25.3 invokes `mamba env create`, whose CLI mamba 2
+  # removed, so an unpinned mamba resolves to 2.x and `--conda-frontend mamba` then fails with a
+  # `CreateCondaEnvironmentException` and no output. This pin matches `cartography_tidy.yml`.
+  - mamba=1.4.2
   - requests=2.29.0
   - pandas=2.0.1
   - pytest=7.4.3

--- a/envs/pandas.yml
+++ b/envs/pandas.yml
@@ -3,4 +3,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  # pinned to match the other environments; see the note in `analysis.yml`.
+  - python=3.9.16
   - pandas=2.0.1

--- a/envs/plotting.yml
+++ b/envs/plotting.yml
@@ -3,6 +3,8 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  # pinned to match the other environments; see the note in `analysis.yml`.
+  - python=3.9.16
   - plotly=5.14.1
   - jupyter-dash=0.4.2
   - matplotlib=3.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,12 @@ requires-python = ">=3.9"
 license = { file = "LICENSE" }
 
 
+[tool.pytest.ini_options]
+markers = [
+    "smoke: an end-to-end run of the whole pipeline with all external calls mocked or stubbed",
+]
+
+
 [tool.ruff]
 # The directories to consider when resolving first- vs. third-party imports
 src = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,11 @@ markers = [
     "smoke: an end-to-end run of the whole pipeline with all external calls mocked or stubbed",
 ]
 
+# The modules in the `ProteinCartography` package import each other by their top-level names,
+# because the snakemake rules call them as scripts from within that directory. Adding it here
+# lets the tests import them the same way.
+pythonpath = ["ProteinCartography"]
+
 
 [tool.ruff]
 # The directories to consider when resolving first- vs. third-party imports


### PR DESCRIPTION
Follow-on to #100 (now merged). Seven fixes found while running the pipeline locally on macOS and on x86-64 Linux. None of them are platform-specific; each was reproduced on both.

### 1. Pin `matplotlib` and `setuptools` in `envs/analysis.yml`

`envs/analysis.yml` pins its seven direct dependencies but nothing transitive, so a fresh solve installs versions incompatible with its pinned `numpy=1.23.5`, and two rules fail:

```
rule leiden_clustering (scanpy -> matplotlib):
  ImportError: Matplotlib requires numpy>=1.25; you have 1.23.5

rule dim_reduction (umap-learn 0.5.3):
  ModuleNotFoundError: No module named 'pkg_resources'
```

`setuptools >= 81` removes `pkg_resources`, which `umap-learn 0.5.3` imports at module scope. The matplotlib failure is an ABI break rather than a dependency conflict: the solver installs a numpy-2-built matplotlib alongside `numpy=1.23.5` without complaint, and it fails only when imported — which is why building the environment never caught it, and why an environment that pins numpy has to pin what is compiled against it. The matplotlib pin matches the one already in `plotting.yml` and `cartography_pub.yml`.

This is not platform-specific: a fresh solve produced matplotlib 3.11.0 on osx-64 and 3.9.4 on linux-64, and the pipeline failed identically on both.

### 2. Remove the `restore-keys` from the conda env cache

`restore-keys` began with `snakemake-conda-` while the key begins with `conda-`, and they are matched as a prefix of the key, so the fallback restore could never fire.

An earlier revision of this branch corrected the prefix. That was wrong, and the correction is reversed here: a `restore-keys` match still leaves `cache-hit` false, so the env creation step runs regardless, and that step begins with `rm -rf .snakemake/conda`. Making the prefix match would therefore download a stale multi-gigabyte cache on every change to `envs/*.yml`, only to delete it — strictly slower than a prefix that never matched. There is no path in which the restored files are used, so the keys are removed instead.

This cache is also why CI did not catch the drift in (1): the key includes `hashFiles('envs/*.yml')`, so while the env files are unchanged CI restores previously solved envs and never re-resolves them against the current package index. That is worth addressing separately — a scheduled job that re-solves from scratch would catch this class of drift before it reaches a PR.

### 3. Add a blast stub and a `make smoke-test` entry point

The `run_blast` rule calls `blastp -remote`, which queues on NCBI's public servers; NCBI's own time-to-completion estimate (`RTOE`) was observed at ~2.5 hours, which makes end-to-end verification impractical.

`run_blast` now copies a canned results file when `PROTEINCARTOGRAPHY_BLAST_STUB_RESULTS_FILEPATH` is set. An env variable is used rather than a CLI flag because snakemake rule environments inherit env variables from the calling process, so neither the Snakefile nor the config needs to change.

This *replaces* `tests.mocks.mock_run_blast`, which patched `blast_utils.run_blast` and so required `run_blast.py` to import the `tests` package — the same class of problem #100 fixes, since importing `tests.mocks` calls `find_repo_dirpath()`.

`make smoke-test` runs the search-mode pipeline with the stub. That test also now asserts on snakemake's return value, **which was previously discarded** (so it could pass while the pipeline failed), and checks that outputs are non-empty rather than merely present.

### 4. Detect failed `blastp` calls that exit with a status of zero

When the remote server refuses to queue a request, `blastp -remote` reports the error on stderr, writes an empty results file, and still exits zero:

```
$ blastp -remote -db nr ... ; echo $?
Error: [blastp] bad_request: Could not queue request: DB operation failed.
0
```

`run_blast.py` branched on `result.returncode == 0`, so it treated this as success. The word-size backoff was never attempted — the situation it exists for — and the empty file surfaced later as a misleading "no hits were returned" from `extract_blast_hits.py`.

An empty results file is deliberately *not* treated as a failure, since a query that legitimately has no hits produces one too.

This does not make the remote call faster; it means a refused request is retried and then reported.

### 5. Pin `mamba` in `envs/cartography_test.yml`

`mamba` was left unpinned and now resolves to mamba 2.x, which removed the `mamba env create` CLI that snakemake 7.25.3 invokes. `--conda-frontend mamba` therefore fails with a `CreateCondaEnvironmentException` and no output from the frontend.

Pinned to `1.4.2`, matching `cartography_tidy.yml`. CI does not hit this because `test.yml` forces the conda frontend, with a comment noting the mamba frontend "results in errors during env creation" — this is that error, and this is its cause. Anyone using the mamba frontend locally does hit it.

Same class of problem as (1): a dependency left unpinned in 2023 that resolves to an incompatible major version today.

### 6. Build the wildcard output paths without f-strings

Two rules built an output path from an f-string mixing an interpolated value with an escaped snakemake wildcard:

```python
f"{ANALYSIS_NAME}_aggregated_features_{{plotting_mode}}.html"
```

The doubled braces render the literal `{plotting_mode}` that snakemake needs as a wildcard. That is easy to misread, and a formatter can silently change its meaning: `make format` under Python 3.12+ rewrites the doubled braces to single ones, turning the wildcard into an interpolation of a name that does not exist. (Python 3.12 changed f-string tokenization, PEP 701; the pinned snakefmt and black predate it.)

The resulting Snakefile would still pass lint and would fail at runtime with a `NameError` in `plot_interactive` and `plot_cluster_distributions`.

Concatenating a plain string avoids the escaping, produces a byte-identical path, and cannot be rewritten. Verified that the DAG resolves the same targets (`..._aggregated_features_pca_umap.html`, `..._P60709_distribution_analysis.svg`) and that `snakefmt --check` now passes under both Python 3.9 (CI's version) and Python 3.12+, where it previously wanted to rewrite the file.

The doubled braces elsewhere in the Snakefile are unaffected: they appear in a plain (non-f) string and in a shell block, neither of which a formatter rewrites.

### 7. Pin `python` in the environments that left it unpinned

`envs/analysis.yml`, `envs/plotting.yml` and `envs/pandas.yml` declare no `python` at all, so each resolves to whatever the newest python conda-forge has builds for. They had drifted apart from each other and from the six environments that do pin it, which are all on `3.9.16`: solved as they were, `analysis.yml` gave python 3.11 and `plotting.yml` gave 3.10.20.

This is what put `analysis.yml` on a python new enough to resolve the `setuptools >= 81` that removes `pkg_resources` — the failure in (1). Pinning the interpreter is the more direct fix for that class of drift than pinning each package that reacts to it.

All three now solve at `3.9.16`.

## Verification

- All three newly-pinned environments solve at python 3.9.16, checked from a snapshot of the env files. The `analysis` environment imports `matplotlib.pyplot`, `pkg_resources` and `umap` — the three imports that were failing.
- `make test`: 11 passed (both pipeline integration tests plus the unit tests)
- `make smoke-test`: 26 of 26 rules complete (~49 s with envs cached)
- Cluster-mode demo end to end: 16 of 16 rules, all `final_results` outputs produced
- `ruff check`, `ruff format --check`, and `snakefmt --check`: clean, using CI's pinned versions (ruff 0.1.6, snakefmt 0.8.5) under Python 3.9
- #100's packaging tests independently confirmed passing on linux/amd64 (Modal)

## Not included

A replacement for the remote BLAST interface is proposed separately in #102, which is stacked on this branch. Benchmarking found that the slowness tracks NCBI's global queue load rather than any of the pipeline's blastp arguments — `-word_size`, `-outfmt`, `-max_target_seqs`, and `shell=True` were all ruled out by probing NCBI's `RTOE` estimate against a control. This PR deliberately keeps `blastp -remote` and only makes its failures visible (4).

