### PR TITLE
Fix search-mode reliability for BLAST, UniProt, AFDB, and small maps

### DIFF
--- a/ProteinCartography/blast_utils.py
+++ b/ProteinCartography/blast_utils.py
@@ -1,4 +1,66 @@
+#!/usr/bin/env python
+"""BLAST runner for ProteinCartography.
+
+Stock ``blastp -remote`` often hangs from cloud IPs with no timeout. This module
+supports a selectable backend:
+
+``PC_BLAST_BACKEND``
+  - ``www`` (default) — NCBI Blast.cgi URL API (Put → RID poll → Get XML),
+    then write the same tabular TSV ProteinCartography expects
+    (``BLAST_OUTFMT`` / ``sacc`` column). This is the systematic fix.
+  - ``remote`` — stock ``blastp -remote`` CLI, with a hard timeout + process-group
+    kill (last resort / local debugging).
+  - ``auto`` — try ``www``, then ``remote``.
+
+Env knobs
+---------
+``PC_BLAST_TIMEOUT`` — overall wall clock (default 1200s for www).
+``PC_BLAST_EMAIL`` / ``PC_BLAST_TOOL`` — NCBI usage-guideline identity.
+``PC_BLAST_POLL_SECONDS`` — RID poll interval (NCBI asks ≥60s; default 60).
+"""
+
+from __future__ import annotations
+import os
+import re
 import subprocess
+import threading
+import time
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+NCBI_BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi"
+
+# Must match ``constants.BLAST_OUTPUT_FIELDS`` order after the leading ``6``
+# in ``BLAST_OUTFMT``.
+BLAST_TSV_FIELDS = [
+    "qseqid",
+    "sseqid",
+    "pident",
+    "length",
+    "mismatch",
+    "gapopen",
+    "qstart",
+    "qend",
+    "sstart",
+    "send",
+    "evalue",
+    "bitscore",
+    "sacc",
+    "saccver",
+    "sgi",
+    "staxids",
+    "scomnames",
+]
+
+
+@dataclass
+class BlastResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
 
 
 def run_blast(
@@ -10,44 +72,436 @@ def run_blast(
     evalue: float,
 ):
     """
-    Call `blastp` against the remote server
+    Call BLAST against NCBI and write tabular results to ``out``.
 
-    Note: the argument names used here correspond exactly to (a subset of the) blastp CLI arguments
-
-    Note: this function is in its own module, rather than in `run_blast.py`,
-    so that it can be mocked by calling `tests.mocks.mock_run_blast` at the top of `run_blast.py`
-
-    Args:
-        query (str): path of input peptide FASTA file.
-        out (str): path of destination blastresults.tsv file.
-        max_target_seqs (int): maximum number of hits to return
-        outfmt (str): passed to blastp '-outfmt'
-        word_size (str): passed to blastp '-word_size'
-        evalue (str): passed to blastp '-evalue'
+    Argument names match (a subset of) the blastp CLI / PC ``run_blast.py``.
+    Never returns ``None``.
     """
-    database = "nr"
-    result = subprocess.run(
-        " ".join(
-            [
-                "blastp",
-                "-remote",
-                "-db",
-                database,
-                "-query",
-                query,
-                "-out",
-                out,
-                "-max_target_seqs",
-                str(max_target_seqs),
-                "-outfmt",
-                f"'{outfmt}'",
-                "-word_size",
-                str(word_size),
-                "-evalue",
-                str(evalue),
-            ]
-        ),
-        capture_output=True,
-        shell=True,
+    backend = os.environ.get("PC_BLAST_BACKEND", "www").strip().lower() or "www"
+    if backend not in {"www", "remote", "auto"}:
+        print(f"[blast] unknown PC_BLAST_BACKEND={backend!r}; using www", flush=True)
+        backend = "www"
+
+    result: BlastResult | None = None
+    try:
+        if backend == "www":
+            result = _run_blast_www(query, out, max_target_seqs, word_size, evalue)
+        elif backend == "remote":
+            result = _run_blast_remote(query, out, max_target_seqs, outfmt, word_size, evalue)
+        else:
+            result = _run_blast_www(query, out, max_target_seqs, word_size, evalue)
+            ok = result is not None and result.returncode == 0 and Path(out).exists()
+            if not ok:
+                print(
+                    "[blast] www backend failed; falling back to blastp -remote",
+                    flush=True,
+                )
+                result = _run_blast_remote(query, out, max_target_seqs, outfmt, word_size, evalue)
+    except Exception as exc:
+        msg = f"[blast] unexpected error in run_blast: {type(exc).__name__}: {exc}\n"
+        print(msg, flush=True)
+        return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+
+    if result is None:
+        msg = "[blast] backend returned None (treating as failure)\n"
+        print(msg, flush=True)
+        return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# NCBI WWW / QBlast (systematic fix)
+# --------------------------------------------------------------------------- #
+
+
+def _run_blast_www(
+    query: str,
+    out: str,
+    max_target_seqs: int,
+    word_size: int,
+    evalue: float,
+) -> BlastResult:
+    timeout = float(os.environ.get("PC_BLAST_TIMEOUT", "1200"))
+    poll = float(os.environ.get("PC_BLAST_POLL_SECONDS", "60"))
+    # NCBI: do not poll a RID more often than once a minute.
+    poll = max(60.0, poll)
+    email = os.environ.get("PC_BLAST_EMAIL", "proteincartography@arcadia.science").strip()
+    tool = os.environ.get("PC_BLAST_TOOL", "ProteinCartography").strip()
+    # Default to ``refseq_protein``: NCBI often queues ``nr`` for hours from cloud
+    # IPs, and map_refseq_ids already expects RefSeq accessions. Override with
+    # ``PC_BLAST_DB=nr`` for the historical broader search.
+    default_db = "refseq_protein"
+    database = os.environ.get("PC_BLAST_DB", default_db).strip() or default_db
+
+    try:
+        fasta = Path(query).read_text()
+    except OSError as exc:
+        msg = f"[blast] cannot read query FASTA {query}: {exc}\n"
+        print(msg, flush=True)
+        return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+
+    print(
+        f"[blast] www/QBlast submit db={database} hitlist={max_target_seqs} "
+        f"word_size={word_size} evalue={evalue} timeout={timeout:.0f}s "
+        f"query={query}",
+        flush=True,
     )
+
+    stop = threading.Event()
+    started = time.time()
+
+    def _heartbeat():
+        while not stop.wait(30.0):
+            elapsed = time.time() - started
+            print(
+                f"[blast] www still waiting on NCBI ({elapsed:.0f}s / {timeout:.0f}s)",
+                flush=True,
+            )
+
+    hb = threading.Thread(target=_heartbeat, name="blast-www-hb", daemon=True)
+    hb.start()
+    try:
+        rid = None
+        rtoe = 30
+        put_errors: list[str] = []
+        for put_try in range(1, 4):
+            try:
+                rid, rtoe = _www_put(
+                    fasta,
+                    database=database,
+                    hitlist_size=max_target_seqs,
+                    word_size=word_size,
+                    evalue=evalue,
+                    email=email,
+                    tool=tool,
+                )
+                break
+            except Exception as exc:
+                put_errors.append(str(exc))
+                print(f"[blast] www PUT try {put_try}/3 failed: {exc}", flush=True)
+                time.sleep(10 * put_try)
+        if rid is None:
+            msg = f"[blast] www PUT failed after retries: {put_errors[-1:]}\n"
+            print(msg, flush=True)
+            return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+
+        print(f"[blast] www RID={rid} RTOE≈{rtoe}s; polling every {poll:.0f}s", flush=True)
+        # Honour NCBI's own estimate (capped) so we don't soft-fail while the
+        # job is still legitimately queued.
+        effective_timeout = max(timeout, min(float(rtoe or 0) + 300.0, 7200.0))
+        if effective_timeout > timeout:
+            print(
+                f"[blast] www extending timeout {timeout:.0f}s → {effective_timeout:.0f}s "
+                f"from RTOE",
+                flush=True,
+            )
+        initial_wait = min(max(float(rtoe or 0), 0.0), 120.0)
+        if initial_wait > 0:
+            time.sleep(initial_wait)
+
+        while True:
+            elapsed = time.time() - started
+            if elapsed > effective_timeout:
+                msg = (
+                    f"[blast] www TIMEOUT after {effective_timeout:.0f}s (RID={rid} RTOE≈{rtoe}s)\n"
+                )
+                print(msg, flush=True)
+                return BlastResult(returncode=124, stdout=b"", stderr=msg.encode())
+            try:
+                status, body = _www_get(rid, email=email, tool=tool)
+            except Exception as exc:
+                print(f"[blast] www poll error (will retry): {exc}", flush=True)
+                time.sleep(poll)
+                continue
+
+            if status == "WAITING":
+                print(
+                    f"[blast] www still waiting on NCBI "
+                    f"({elapsed:.0f}s / {effective_timeout:.0f}s RID={rid})",
+                    flush=True,
+                )
+                time.sleep(poll)
+                continue
+            if status == "FAILED":
+                msg = f"[blast] www search FAILED (RID={rid})\n{body[:500]}\n"
+                print(msg, flush=True)
+                return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+            if status == "UNKNOWN":
+                msg = f"[blast] www unknown status (RID={rid})\n{body[:500]}\n"
+                print(msg, flush=True)
+                return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+
+            try:
+                n = _xml_to_blast_tsv(body, out)
+            except Exception as exc:
+                msg = f"[blast] www XML→TSV failed: {exc}\n"
+                print(msg, flush=True)
+                return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+            print(
+                f"[blast] www finished RID={rid} hits_rows={n} out={out} "
+                f"elapsed={time.time() - started:.0f}s",
+                flush=True,
+            )
+            return BlastResult(returncode=0, stdout=b"", stderr=b"")
+    finally:
+        stop.set()
+    # Defensive: try/finally without an explicit return yields None in some paths.
+    return BlastResult(
+        returncode=1,
+        stdout=b"",
+        stderr=b"[blast] www backend exited without a result\n",
+    )
+
+
+def _www_put(
+    fasta: str,
+    *,
+    database: str,
+    hitlist_size: int,
+    word_size: int,
+    evalue: float,
+    email: str,
+    tool: str,
+) -> tuple[str, int]:
+    params = {
+        "CMD": "Put",
+        "PROGRAM": "blastp",
+        "DATABASE": database,
+        "QUERY": fasta,
+        "EXPECT": str(evalue),
+        "WORD_SIZE": str(word_size),
+        "HITLIST_SIZE": str(hitlist_size),
+        "FILTER": "F",
+        "FORMAT_TYPE": "XML",
+        "CLIENT": "web",
+        "EMAIL": email,
+        "TOOL": tool,
+    }
+    data = urllib.parse.urlencode(params).encode()
+    req = urllib.request.Request(
+        NCBI_BLAST_URL,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        text = resp.read().decode("utf-8", errors="replace")
+    rid_m = re.search(r"RID\s*=\s*([A-Za-z0-9_-]+)", text)
+    rtoe_m = re.search(r"RTOE\s*=\s*(\d+)", text)
+    if not rid_m:
+        raise RuntimeError(f"no RID in PUT response: {text[:400]}")
+    return rid_m.group(1), int(rtoe_m.group(1)) if rtoe_m else 30
+
+
+def _www_get(rid: str, *, email: str, tool: str) -> tuple[str, str]:
+    params = {
+        "CMD": "Get",
+        "RID": rid,
+        "FORMAT_TYPE": "XML",
+        "EMAIL": email,
+        "TOOL": tool,
+    }
+    url = NCBI_BLAST_URL + "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        text = resp.read().decode("utf-8", errors="replace")
+
+    if "Status=WAITING" in text or "Status = WAITING" in text:
+        return "WAITING", text
+    if "Status=FAILED" in text or "Status = FAILED" in text:
+        return "FAILED", text
+    if "Status=UNKNOWN" in text or "Status = UNKNOWN" in text:
+        return "UNKNOWN", text
+    # Ready results are BlastOutput XML (no Status= line, or Status=READY).
+    if "<BlastOutput" in text or "Status=READY" in text or "Status = READY" in text:
+        return "READY", text
+    # Sometimes NCBI still returns HTML chrome while waiting.
+    if "RID =" in text and "QBlastInfoBegin" in text:
+        return "WAITING", text
+    return "READY", text
+
+
+def _xml_to_blast_tsv(xml_text: str, out_path: str) -> int:
+    """Convert NCBI BlastOutput XML into PC ``BLAST_OUTFMT`` tabular TSV."""
+    # Strip any leading HTML/status wrapper if present.
+    start = xml_text.find("<BlastOutput")
+    if start < 0:
+        Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(out_path).write_text("")
+        return 0
+    xml_text = xml_text[start:]
+    root = ET.fromstring(xml_text)
+
+    query_id = ""
+    for el in root.iter():
+        if el.tag == "BlastOutput_query-def" or el.tag.endswith("}BlastOutput_query-def"):
+            query_id = (el.text or "").split()[0] if el.text else ""
+            break
+        if el.tag == "Iteration_query-def" or el.tag.endswith("}Iteration_query-def"):
+            query_id = (el.text or "").split()[0] if el.text else ""
+            break
+
+    rows: list[list[str]] = []
+    for hit in root.iter():
+        if not (hit.tag == "Hit" or hit.tag.endswith("}Hit")):
+            continue
+        hit_id = ""
+        hit_acc = ""
+        hit_def = ""
+        for child in list(hit):
+            tag = child.tag.split("}")[-1]
+            if tag == "Hit_id":
+                hit_id = (child.text or "").strip()
+            elif tag == "Hit_accession":
+                hit_acc = (child.text or "").strip()
+            elif tag == "Hit_def":
+                hit_def = (child.text or "").strip()
+        if not hit_acc and hit_id:
+            # ref|XP_123| or gi|…|ref|XP_123.1|
+            m = re.search(r"(?:ref\|)?([A-Z0-9_]+)(?:\.\d+)?\|?", hit_id)
+            if m:
+                hit_acc = m.group(1)
+
+        for hsp in hit.iter():
+            if not (hsp.tag == "Hsp" or hsp.tag.endswith("}Hsp")):
+                continue
+            # Skip nested false positives: only real Hsp elements have Hsp_* kids.
+            hsp_map = {}
+            for c in list(hsp):
+                hsp_map[c.tag.split("}")[-1]] = (c.text or "").strip()
+            if "Hsp_evalue" not in hsp_map and "Hsp_bit-score" not in hsp_map:
+                continue
+
+            fields = {name: "" for name in BLAST_TSV_FIELDS}
+            fields["qseqid"] = query_id
+            fields["sseqid"] = hit_id
+            fields["sacc"] = hit_acc
+            fields["saccver"] = hit_acc
+            fields["scomnames"] = hit_def[:80].replace("\t", " ")
+
+            align_len = float(hsp_map.get("Hsp_align-len") or 0) or 1.0
+            identity = float(hsp_map.get("Hsp_identity") or 0)
+            fields["pident"] = f"{(100.0 * identity / align_len):.3f}"
+            fields["length"] = hsp_map.get("Hsp_align-len", "")
+            fields["mismatch"] = str(
+                max(
+                    0,
+                    int(align_len)
+                    - int(float(hsp_map.get("Hsp_identity") or 0))
+                    - int(float(hsp_map.get("Hsp_gaps") or 0)),
+                )
+            )
+            fields["gapopen"] = hsp_map.get("Hsp_gaps", "0")
+            fields["qstart"] = hsp_map.get("Hsp_query-from", "")
+            fields["qend"] = hsp_map.get("Hsp_query-to", "")
+            fields["sstart"] = hsp_map.get("Hsp_hit-from", "")
+            fields["send"] = hsp_map.get("Hsp_hit-to", "")
+            fields["evalue"] = hsp_map.get("Hsp_evalue", "")
+            fields["bitscore"] = hsp_map.get("Hsp_bit-score", "")
+            rows.append([fields[name] for name in BLAST_TSV_FIELDS])
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as fh:
+        for row in rows:
+            fh.write("\t".join(row) + "\n")
+    return len(rows)
+
+
+# --------------------------------------------------------------------------- #
+# Legacy blastp -remote (timeout-guarded)
+# --------------------------------------------------------------------------- #
+
+
+def _run_blast_remote(
+    query: str,
+    out: str,
+    max_target_seqs: int,
+    outfmt: str,
+    word_size: int,
+    evalue: float,
+) -> BlastResult:
+    database = os.environ.get("PC_BLAST_DB", "nr").strip() or "nr"
+    timeout = float(os.environ.get("PC_BLAST_TIMEOUT", "900"))
+    cmd = [
+        "blastp",
+        "-remote",
+        "-db",
+        database,
+        "-query",
+        query,
+        "-out",
+        out,
+        "-max_target_seqs",
+        str(max_target_seqs),
+        "-outfmt",
+        outfmt,
+        "-word_size",
+        str(word_size),
+        "-evalue",
+        str(evalue),
+    ]
+    print(
+        f"[blast] remote blastp db={database} "
+        f"max_target_seqs={max_target_seqs} word_size={word_size} "
+        f"timeout={timeout:.0f}s query={query}",
+        flush=True,
+    )
+
+    stop = threading.Event()
+
+    def _heartbeat():
+        started = time.time()
+        while not stop.wait(30.0):
+            elapsed = time.time() - started
+            print(
+                f"[blast] still waiting on NCBI remote blastp ({elapsed:.0f}s / {timeout:.0f}s)",
+                flush=True,
+            )
+
+    hb = threading.Thread(target=_heartbeat, name="blast-remote-hb", daemon=True)
+    hb.start()
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            stop.set()
+            try:
+                os.killpg(proc.pid, 15)
+            except ProcessLookupError:
+                pass
+            try:
+                stdout, stderr = proc.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(proc.pid, 9)
+                except ProcessLookupError:
+                    pass
+                stdout, stderr = proc.communicate()
+            msg = (
+                f"\n[blast] TIMEOUT after {timeout:.0f}s waiting on NCBI remote blastp\n"
+            ).encode()
+            print(f"[blast] TIMEOUT after {timeout:.0f}s", flush=True)
+            return BlastResult(
+                returncode=124,
+                stdout=stdout or b"",
+                stderr=(stderr or b"") + msg,
+            )
+        result = BlastResult(returncode=proc.returncode, stdout=stdout, stderr=stderr)
+    finally:
+        stop.set()
+
+    if result.stderr:
+        try:
+            err_tail = result.stderr.decode("utf-8", errors="replace")[-500:]
+        except Exception:
+            err_tail = "<binary stderr>"
+        if err_tail.strip():
+            print(f"[blast] blastp stderr (tail):\n{err_tail}", flush=True)
+    print(f"[blast] blastp finished rc={result.returncode}", flush=True)
     return result

--- a/ProteinCartography/constants.py
+++ b/ProteinCartography/constants.py
@@ -1,5 +1,6 @@
 # default column names for a Foldseek run in this pipeline
 import enum
+import os
 
 FOLDSEEK_COLUMN_NAMES = [
     "query",
@@ -62,3 +63,17 @@ BLAST_OUTPUT_FIELDS = [
 
 # the prepended '6' is how we specify that the output format is tabular
 BLAST_OUTFMT = " ".join(["6"] + BLAST_OUTPUT_FIELDS)
+
+
+def blast_soft_fail_enabled() -> bool:
+    """True only for an explicit PC_BLAST_SOFT_FAIL opt-in. Default is hard-fail.
+
+    Shared by ``run_blast`` and ``extract_blast_hits`` so an empty BLAST TSV
+    cannot succeed one step and abort the next.
+    """
+    return os.environ.get("PC_BLAST_SOFT_FAIL", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }

--- a/ProteinCartography/dim_reduction.py
+++ b/ProteinCartography/dim_reduction.py
@@ -104,10 +104,10 @@ def calculate_TSNE(
             index=pivoted_df.index,
         )
     else:
-        # sklearn requires perplexity < n_samples.
+        # sklearn requires perplexity < n_samples. Clamp only for that;
+        # do not also scale perplexity for every N under 250 (that shifts
+        # ordinary maps, e.g. N=100 from 50 → 21).
         perplexity_check = min(perplexity, max(1, n - 1))
-        if perplexity_check > n / 5:
-            perplexity_check = max(1, int(1 + np.round(n / 5)))
         perplexity_check = min(perplexity_check, n - 1)
         tsne = TSNE(
             n_components=min(n_components, max(1, n - 1)),

--- a/ProteinCartography/dim_reduction.py
+++ b/ProteinCartography/dim_reduction.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+"""Dimensionality reduction for ProteinCartography similarity matrices.
+
+Clamps UMAP/t-SNE parameters for small N and falls back to a PCA/identity
+layout when N < 3 so tiny maps still produce coordinates.
+"""
+
+from __future__ import annotations
 import argparse
 
 import numpy as np
@@ -7,21 +14,14 @@ from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 from umap import UMAP
 
-# only import these functions when using import *
 __all__ = ["calculate_PCA", "calculate_TSNE", "calculate_UMAP"]
 
 MODES = ["pca", "tsne", "umap", "pca_tsne", "pca_umap"]
 
 
-# parse command line arguments
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-i",
-        "--input",
-        required=True,
-        help="Path to input all-v-all similarity matrix.",
-    )
+    parser.add_argument("-i", "--input", required=True)
     parser.add_argument("-p", "--output-prefix", help="Prefix for resulting .tsv files.")
     parser.add_argument(
         "-m",
@@ -35,9 +35,13 @@ def parse_args():
         default="123456",
         help="Random state for umap and tsne modes.",
     )
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    return args
+
+def _save_path(pivot_file: str, saveprefix: str | None, dimtype: str) -> str:
+    if saveprefix is not None:
+        return "_".join([saveprefix, dimtype + ".tsv"])
+    return pivot_file.replace(".tsv", "_" + dimtype + ".tsv")
 
 
 def calculate_PCA(
@@ -49,27 +53,11 @@ def calculate_PCA(
     prep_step=False,
     **kwargs,
 ):
-    """
-    Calculates the n-component PCA of an all-v-all similarity matrix.
-    The matrix should be a square, where rows and columns are identical
-    and each cell is a similarity score.
-
-    Args:
-        pivot_file (str): path to a matrix of values.
-        n_components (int): number of components to calculate. Default 2.
-        save (bool): whether or not to save the file.
-        saveprefix (str): prefix of file to save to.
-        dimtype (str): defaults to 'pca'. included in save file output name.
-        prep_step (bool): if set to True, returns the path of the saved file.
-        **kwargs are passed to `sklearn.decomposition.PCA`.
-    Returns:
-        a pandas.DataFrame containing the PCA results, or a path to the saved file.
-    """
-    # Read input file
     pivoted_df = pd.read_csv(pivot_file, sep="\t", index_col="protid")
 
-    # check that the data is large enough to support the specified number of principal components
     max_n_components = min(pivoted_df.shape)
+    if max_n_components < 1:
+        raise ValueError(f"empty similarity matrix: {pivot_file}")
     if n_components > max_n_components:
         print(
             f"Warning: the specified value of `n_components` ({n_components})"
@@ -78,32 +66,20 @@ def calculate_PCA(
         )
         n_components = max_n_components
 
-    # Initialize and run PCA
     pca = PCA(n_components=n_components, **kwargs)
     pca_results = pca.fit_transform(pivoted_df)
-
-    # Read PCA results data
     pca_results_df = pd.DataFrame(
         pca_results,
         columns=[f"PC{i}" for i in range(pca_results.shape[1])],
         index=pivoted_df.index,
     )
 
-    # Generate savefile name
-    if saveprefix is not None:
-        savefile = "_".join([saveprefix, dimtype + ".tsv"])
-    else:
-        savefile = pivot_file.replace(".tsv", "_" + dimtype + ".tsv")
-
-    # Save if needed
+    savefile = _save_path(pivot_file, saveprefix, dimtype)
     if save:
         pca_results_df.to_csv(savefile, sep="\t")
-
-    # Return either the path to the destination file or the results dataframe
     if prep_step:
         return savefile
-    else:
-        return pca_results_df
+    return pca_results_df
 
 
 def calculate_TSNE(
@@ -117,64 +93,72 @@ def calculate_TSNE(
     dimtype="tsne",
     **kwargs,
 ):
-    """
-    Calculates the TSNE of an all-v-all similarity matrix given a random state, perplexity,
-    and number of iterations.
-    The matrix should be a square, where rows and columns are identical
-    and each cell is a similarity score.
-
-    Args:
-        pivot_file (str): path to a matrix of values.
-        random_state (int): random state used for initializing TSNE.
-        n_components (int): number of components to return. Default 2.
-        perplexity (int): `sklearn.manifold.TSNE` perplexity.
-        n_iter (int): iteractions to run with TSNE.
-        save (bool): whether or not to save the file.
-        saveprefix (str): prefix of file to save to.
-        dimtype (str): defaults to 'tsne'. included in save file output name.
-        **kwargs are passed to `sklearn.manifold.TSNE`.
-    Returns:
-        a pandas.DataFrame containing the TSNE results, or a path to the saved file.
-    """
-    # Read input file
     pivoted_df = pd.read_csv(pivot_file, sep="\t", index_col="protid")
-
-    # Check to make sure perplexity is lower than the total number of elements
-    # If not, set perplexity to 1/5 of elements
-    if perplexity > len(pivoted_df):
-        perplexity_check = int(1 + np.round(len(pivoted_df) / 5))
+    n = len(pivoted_df)
+    if n < 2:
+        # Single point — emit a degenerate layout.
+        coords = np.zeros((n, n_components), dtype=float)
+        tsne_results_df = pd.DataFrame(
+            coords,
+            columns=[f"tSNE{i + 1}" for i in range(n_components)],
+            index=pivoted_df.index,
+        )
     else:
-        perplexity_check = perplexity
+        # sklearn requires perplexity < n_samples.
+        perplexity_check = min(perplexity, max(1, n - 1))
+        if perplexity_check > n / 5:
+            perplexity_check = max(1, int(1 + np.round(n / 5)))
+        perplexity_check = min(perplexity_check, n - 1)
+        tsne = TSNE(
+            n_components=min(n_components, max(1, n - 1)),
+            perplexity=float(perplexity_check),
+            n_iter=n_iter,
+            random_state=random_state,
+            **kwargs,
+        )
+        tsne_results = tsne.fit_transform(pivoted_df)
+        # Pad to requested components if sklearn reduced them.
+        if tsne_results.shape[1] < n_components:
+            pad = np.zeros((n, n_components - tsne_results.shape[1]))
+            tsne_results = np.hstack([tsne_results, pad])
+        tsne_results_df = pd.DataFrame(
+            tsne_results[:, :n_components],
+            columns=[f"tSNE{i + 1}" for i in range(n_components)],
+            index=pivoted_df.index,
+        )
 
-    # Intialize and run TSNE
-    tsne = TSNE(
-        n_components=n_components,
-        perplexity=perplexity_check,
-        n_iter=n_iter,
-        random_state=random_state,
-        **kwargs,
-    )
-    tsne_results = tsne.fit_transform(pivoted_df)
-
-    # Read TSNE results data
-    tsne_results_df = pd.DataFrame(
-        tsne_results,
-        columns=[f"tSNE{i + 1}" for i in range(tsne_results.ndim)],
-        index=pivoted_df.index,
-    )
-
-    # Generate savefile name
-    if saveprefix is not None:
-        savefile = "_".join([saveprefix, dimtype + ".tsv"])
-    else:
-        savefile = pivot_file.replace(".tsv", "_" + dimtype + ".tsv")
-
-    # Save if needed
+    savefile = _save_path(pivot_file, saveprefix, dimtype)
     if save:
         tsne_results_df.to_csv(savefile, sep="\t")
-
-    # Return results
     return tsne_results_df
+
+
+def _small_n_layout(pivoted_df: pd.DataFrame, n_components: int, prefix: str) -> pd.DataFrame:
+    """PCA or identity layout when N is too small for UMAP/t-SNE."""
+    n = len(pivoted_df)
+    if n == 0:
+        raise ValueError("empty matrix")
+    if n == 1:
+        coords = np.zeros((1, n_components), dtype=float)
+    else:
+        # Prefer existing PC columns if this is already a PCA matrix.
+        pc_cols = [c for c in pivoted_df.columns if str(c).startswith("PC")]
+        if len(pc_cols) >= n_components:
+            coords = pivoted_df[pc_cols[:n_components]].to_numpy(dtype=float)
+        else:
+            k = min(n_components, n, pivoted_df.shape[1])
+            pca = PCA(n_components=k)
+            reduced = pca.fit_transform(pivoted_df)
+            if reduced.shape[1] < n_components:
+                pad = np.zeros((n, n_components - reduced.shape[1]))
+                coords = np.hstack([reduced, pad])
+            else:
+                coords = reduced[:, :n_components]
+    return pd.DataFrame(
+        coords,
+        columns=[f"{prefix}{i + 1}" for i in range(n_components)],
+        index=pivoted_df.index,
+    )
 
 
 def calculate_UMAP(
@@ -188,100 +172,61 @@ def calculate_UMAP(
     dimtype="umap",
     **kwargs,
 ):
-    """
-    Calculates the UMAP of an all-v-all similarity matrix given a random state,
-    number of neighbors, and minimum distance.
-    The matrix should be a square, where rows and columns are identical
-    and each cell is a similarity score.
-
-    Args:
-        pivot_file (str): path to a matrix of values.
-        random_state (int): random state used for initializing UMAP.
-        n_components (int): number of components to return. Default 2.
-        n_neighbors (int): number of neighbors.
-        min_dist (int): minimum distance between neighbors.
-        save (bool): whether or not to save the file.
-        saveprefix (str): prefix of file to save to.
-        dimtype (str): defaults to 'tsne'. included in save file output name.
-        **kwargs are passed to `umap.UMAP`.
-    Returns:
-        a pandas.DataFrame containing the TSNE results, or a path to the saved file.
-    """
-    # Read input file
     pivoted_df = pd.read_csv(pivot_file, sep="\t", index_col="protid")
+    n = len(pivoted_df)
 
-    # Check to make sure number of neighbors isn't greater than the whole dataset
-    # If it is, set number of neighbors to 1/5 of data
-    if n_neighbors > len(pivoted_df):
-        neighbors_check = int(1 + np.round(len(pivoted_df) / 5))
+    # umap-learn requires n_neighbors >= 2 and n_neighbors < n (effectively ≤ n-1).
+    if n < 3:
+        print(
+            f"[dim_reduction] N={n} too small for UMAP; writing PCA/identity layout "
+            f"as {dimtype} coordinates",
+            flush=True,
+        )
+        umap_results_df = _small_n_layout(pivoted_df, n_components, "UMAP")
     else:
-        neighbors_check = n_neighbors
+        neighbors_check = min(int(n_neighbors), n - 1)
+        neighbors_check = max(2, neighbors_check)
+        umap_fxn = UMAP(
+            n_components=n_components,
+            random_state=random_state,
+            n_neighbors=neighbors_check,
+            min_dist=min_dist,
+            **kwargs,
+        )
+        umap_results = umap_fxn.fit_transform(pivoted_df)
+        umap_results_df = pd.DataFrame(
+            umap_results,
+            columns=[f"UMAP{i + 1}" for i in range(umap_results.shape[1])],
+            index=pivoted_df.index,
+        )
 
-    # Initialize and run UMAP
-    umap_fxn = UMAP(
-        n_components=n_components,
-        random_state=random_state,
-        n_neighbors=neighbors_check,
-        min_dist=min_dist,
-        **kwargs,
-    )
-    umap_results = umap_fxn.fit_transform(pivoted_df)
-
-    # Read UMAP results data
-    umap_results_df = pd.DataFrame(
-        umap_results,
-        columns=[f"UMAP{i + 1}" for i in range(umap_results.ndim)],
-        index=pivoted_df.index,
-    )
-
-    # Generate savefile name
-    if saveprefix is not None:
-        savefile = "_".join([saveprefix, dimtype + ".tsv"])
-    else:
-        savefile = pivot_file.replace(".tsv", "_" + dimtype + ".tsv")
-
-    # Save if needed
+    savefile = _save_path(pivot_file, saveprefix, dimtype)
     if save:
         umap_results_df.to_csv(savefile, sep="\t")
-
-    # Return results
     return umap_results_df
 
 
-# run this if called from the interpreter
 def main():
     args = parse_args()
     pivot_file = args.input
     saveprefix = args.output_prefix
     mode = args.mode.lower()
 
-    # Set a random state based on user input
-    # Or use default value
     try:
         random_state = int(args.random_state)
     except Exception:
         random_state = 123456
 
-    # Check whether modes are valid
     if mode not in MODES:
         raise Exception(f"{mode} provided is not valid.\nValid modes include {MODES}.")
 
-    # Calculate vanilla PCA
     if mode == "pca":
         calculate_PCA(pivot_file, save=True, saveprefix=saveprefix)
-
-    # Calculate TSNE
     elif mode == "tsne":
         calculate_TSNE(pivot_file, random_state, save=True, saveprefix=saveprefix)
-
-    # Calcualte UMAP
     elif mode == "umap":
         calculate_UMAP(pivot_file, random_state, save=True, saveprefix=saveprefix)
-
-    # First run 30-component PCA and pass that space to TSNE
     elif mode == "pca_tsne":
-        # Generate temporary save prefix to avoid collisions if run simultaneously
-        # with other PCA calls
         saveprefix1 = pivot_file.replace(".tsv", "temp1")
         pca_results_file = calculate_PCA(
             pivot_file,
@@ -290,14 +235,9 @@ def main():
             n_components=30,
             prep_step=True,
         )
-
         saveprefix2 = pca_results_file.replace("temp1", "").replace(".tsv", "")
         calculate_TSNE(pca_results_file, random_state, save=True, saveprefix=saveprefix2)
-
-    # First run 30-component PCA and pass that space to UMAP
     elif mode == "pca_umap":
-        # Generate temporary save prefix to avoid collisions if run simultaneously
-        # with other PCA calls
         saveprefix1 = pivot_file.replace(".tsv", "temp2")
         pca_results_file = calculate_PCA(
             pivot_file,
@@ -306,11 +246,9 @@ def main():
             n_components=30,
             prep_step=True,
         )
-
         saveprefix2 = pca_results_file.replace("temp2", "").replace(".tsv", "")
         calculate_UMAP(pca_results_file, random_state, save=True, saveprefix=saveprefix2)
 
 
-# check if called from interpreter
 if __name__ == "__main__":
     main()

--- a/ProteinCartography/extract_blast_hits.py
+++ b/ProteinCartography/extract_blast_hits.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 """Extract RefSeq accessions from a BLAST results TSV.
 
-An empty BLAST results file writes an empty hits file instead of raising, so
-Foldseek-only maps can proceed when BLAST soft-fails or returns no hits.
+An empty BLAST results file raises by default so a zero-hit map cannot look
+like success. Set ``PC_BLAST_SOFT_FAIL=1`` to write an empty hits file instead
+and continue Foldseek-only.
 """
 
 from __future__ import annotations
 import argparse
-import os
 from pathlib import Path
 
 import constants
@@ -45,14 +45,9 @@ def extract_blast_hits(input_file: str, output_file: str, column_names: list):
     and prints unique hits to a .txt file, one per line.
     """
     path = Path(input_file)
-    # Empty hits are allowed by default. Set PC_BLAST_SOFT_FAIL=0 to restore the
-    # historical hard failure on empty BLAST results.
-    soft = os.environ.get("PC_BLAST_SOFT_FAIL", "1").strip().lower() not in {
-        "0",
-        "false",
-        "no",
-        "off",
-    }
+    # Same flag as run_blast (default hard-fail). An empty TSV is only
+    # allowed through when PC_BLAST_SOFT_FAIL is an explicit opt-in.
+    soft = constants.blast_soft_fail_enabled()
 
     if not path.exists() or path.stat().st_size == 0:
         print(f"[blast] no BLAST results in {input_file}; writing empty hits file", flush=True)

--- a/ProteinCartography/extract_blast_hits.py
+++ b/ProteinCartography/extract_blast_hits.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python
+"""Extract RefSeq accessions from a BLAST results TSV.
+
+An empty BLAST results file writes an empty hits file instead of raising, so
+Foldseek-only maps can proceed when BLAST soft-fails or returns no hits.
+"""
+
+from __future__ import annotations
 import argparse
+import os
+from pathlib import Path
 
 import constants
 import pandas as pd
 
-# only import these functions when using import *
 __all__ = ["extract_blast_hits"]
 
 
-# parse command line arguments
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -29,34 +36,51 @@ def parse_args():
         default=constants.BLAST_OUTFMT,
         help=f"BLAST query format string.\n Defaults to '{constants.BLAST_OUTFMT}'",
     )
-    args = parser.parse_args()
-
-    return args
+    return parser.parse_args()
 
 
-# take an input blastresults file and create a .txt file from that
 def extract_blast_hits(input_file: str, output_file: str, column_names: list):
     """
     Takes an input blast_results.tsv file, reads the accessions,
     and prints unique hits to a .txt file, one per line.
-
-    Args:
-        input_file (str): path of input blast_results.tsv file.
-        output_file (str): path of destination blast_hits.txt file.
-        names (str): names of columns of blast results.
     """
+    path = Path(input_file)
+    # Empty hits are allowed by default. Set PC_BLAST_SOFT_FAIL=0 to restore the
+    # historical hard failure on empty BLAST results.
+    soft = os.environ.get("PC_BLAST_SOFT_FAIL", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+    if not path.exists() or path.stat().st_size == 0:
+        print(f"[blast] no BLAST results in {input_file}; writing empty hits file", flush=True)
+        Path(output_file).write_text("")
+        if soft:
+            return
+        raise Exception("No hits were returned. Check to see if remote BLAST failed.")
+
     df = pd.read_csv(input_file, sep="\t", names=column_names)
+    if "sacc" not in df.columns or df.empty:
+        print("[blast] BLAST results missing sacc / empty; writing empty hits file", flush=True)
+        Path(output_file).write_text("")
+        if soft:
+            return
+        raise Exception("No hits were returned. Check to see if remote BLAST failed.")
 
-    hits = df["sacc"].unique()
-
+    hits = df["sacc"].dropna().unique()
     if len(hits) == 0:
+        print("[blast] zero sacc hits; writing empty hits file", flush=True)
+        Path(output_file).write_text("")
+        if soft:
+            return
         raise Exception("No hits were returned. Check to see if remote BLAST failed.")
 
     with open(output_file, "w+") as f:
         f.writelines(hit + "\n" for hit in hits)
 
 
-# run this if called from the interpreter
 def main():
     args = parse_args()
     blast_column_names = [name for name in args.blast_format_string.split(" ") if name != "6"]
@@ -65,6 +89,5 @@ def main():
     )
 
 
-# check if called from interpreter
 if __name__ == "__main__":
     main()

--- a/ProteinCartography/fetch_accession.py
+++ b/ProteinCartography/fetch_accession.py
@@ -1,15 +1,26 @@
 #!/usr/bin/env python
+"""Fetch FASTA / AlphaFold PDB for a UniProt accession.
+
+Prefer AlphaFold ``model_v6``, fall back to ``v4``, then the AFDB prediction
+API ``pdbUrl``. Never persist HTML/XML error bodies as PDB files (retired AFDB
+URLs previously wrote S3 ``NoSuchKey`` XML that poisoned downstream Foldseek).
+"""
+
+from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
 
 from api_utils import UniProtWithExpBackoff, session_with_retry
 
-# only import these functions when using import *
 __all__ = ["fetch_fasta", "fetch_pdb"]
 
+AFDB_FILES = "https://alphafold.ebi.ac.uk/files/AF-{acc}-F1-model_{ver}.pdb"
+AFDB_PREDICTION = "https://alphafold.ebi.ac.uk/api/prediction/{acc}"
+# Newest first; v4 kept as a short-lived fallback for mirrors that lag.
+AFDB_VERSIONS = ("v6", "v4")
 
-# parse command line arguments
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -55,6 +66,46 @@ def fetch_fasta(accession: str, output_dir: str):
             file.write(res)
 
 
+def _looks_like_pdb(text: str) -> bool:
+    if not text or not text.strip():
+        return False
+    # AF / ESMFold PDBs always have ATOM/HETATM; error pages have <Error> or HTML.
+    if "<Error>" in text or "<html" in text.lower():
+        return False
+    return "ATOM" in text or "HETATM" in text
+
+
+def _download_pdb_text(accession: str, session) -> str | None:
+    for ver in AFDB_VERSIONS:
+        url = AFDB_FILES.format(acc=accession, ver=ver)
+        try:
+            result = session.get(url, timeout=120)
+        except Exception as exc:
+            print(f"AlphaFold {ver} fetch failed for {accession}: {exc}")
+            continue
+        if result.ok and _looks_like_pdb(result.text):
+            return result.text
+        print(
+            f"AlphaFold {ver} miss for {accession}: "
+            f"status={result.status_code} bytes={len(result.text or '')}"
+        )
+
+    # Prediction API returns the current pdbUrl (version-agnostic).
+    try:
+        meta = session.get(AFDB_PREDICTION.format(acc=accession), timeout=60)
+        if meta.ok:
+            entries = meta.json()
+            if entries:
+                pdb_url = entries[0].get("pdbUrl") or entries[0].get("pdbFile")
+                if pdb_url:
+                    result = session.get(pdb_url, timeout=120)
+                    if result.ok and _looks_like_pdb(result.text):
+                        return result.text
+    except Exception as exc:
+        print(f"AlphaFold API fetch failed for {accession}: {exc}")
+    return None
+
+
 def fetch_pdb(accession: str, output_dir: str, session=None):
     """
     Fetches a PDB file from AlphaFold, given an accession. Places the file in the output_dir.
@@ -66,21 +117,31 @@ def fetch_pdb(accession: str, output_dir: str, session=None):
         session (requests.Session, optional): the requests session to use for the request.
     """
     output_path = Path(output_dir) / f"{accession}.pdb"
-    source = f"https://alphafold.ebi.ac.uk/files/AF-{accession}-F1-model_v6.pdb"
 
     if session is None:
         session = session_with_retry()
 
-    if not os.path.exists(output_path):
-        result = session.get(source)
+    if os.path.exists(output_path):
+        # Re-fetch if a previous run left an AF error stub.
+        try:
+            existing = output_path.read_text(errors="replace")
+        except OSError:
+            existing = ""
+        if _looks_like_pdb(existing):
+            return
+        try:
+            output_path.unlink()
+        except OSError:
+            pass
 
-        # Write an output file regardless of the return code and message. The pipeline will filter
-        # any error results when processing.
-        with open(output_path, "w") as file:
-            file.write(result.text)
+    text = _download_pdb_text(accession, session)
+    if text is None:
+        print(f"No AlphaFold PDB for {accession}; skipping file write")
+        return
+    with open(output_path, "w") as file:
+        file.write(text)
 
 
-# run this if called from the interpreter
 def main():
     args = parse_args()
     accessions = args.accession
@@ -95,6 +156,5 @@ def main():
             fetch_pdb(accession, output_dir)
 
 
-# check if called from interpreter
 if __name__ == "__main__":
     main()

--- a/ProteinCartography/fetch_accession.py
+++ b/ProteinCartography/fetch_accession.py
@@ -75,7 +75,45 @@ def _looks_like_pdb(text: str) -> bool:
     return "ATOM" in text or "HETATM" in text
 
 
+def _pdb_from_response(result) -> str | None:
+    """Return PDB text only for a successful HTTP body that looks like a PDB.
+
+    AlphaFold file URLs 404 with a ~127-byte ``<Error>`` body for accessions
+    whose real entry is an isoform (e.g. Q9Y6V0 → AF-Q9Y6V0-3-F1). Never treat
+    that as a structure.
+    """
+    if result is None:
+        return None
+    text = getattr(result, "text", "") or ""
+    if getattr(result, "ok", False) and _looks_like_pdb(text):
+        return text
+    return None
+
+
 def _download_pdb_text(accession: str, session) -> str | None:
+    # Prefer the prediction API: guessed AF-{acc}-F1 URLs 404 when the AFDB
+    # entry uses an isoform id (Q9Y6V0 → AF-Q9Y6V0-3-F1-model_v6.pdb).
+    try:
+        meta = session.get(AFDB_PREDICTION.format(acc=accession), timeout=60)
+        if getattr(meta, "ok", False):
+            entries = meta.json()
+            if isinstance(entries, list):
+                for entry in entries:
+                    pdb_url = (entry or {}).get("pdbUrl") or (entry or {}).get("pdbFile")
+                    if not pdb_url:
+                        continue
+                    result = session.get(pdb_url, timeout=120)
+                    text = _pdb_from_response(result)
+                    if text:
+                        return text
+                    print(
+                        f"AlphaFold pdbUrl miss for {accession}: "
+                        f"status={getattr(result, 'status_code', '?')} "
+                        f"bytes={len(getattr(result, 'text', '') or '')}"
+                    )
+    except Exception as exc:
+        print(f"AlphaFold API fetch failed for {accession}: {exc}")
+
     for ver in AFDB_VERSIONS:
         url = AFDB_FILES.format(acc=accession, ver=ver)
         try:
@@ -83,26 +121,14 @@ def _download_pdb_text(accession: str, session) -> str | None:
         except Exception as exc:
             print(f"AlphaFold {ver} fetch failed for {accession}: {exc}")
             continue
-        if result.ok and _looks_like_pdb(result.text):
-            return result.text
+        text = _pdb_from_response(result)
+        if text:
+            return text
         print(
             f"AlphaFold {ver} miss for {accession}: "
-            f"status={result.status_code} bytes={len(result.text or '')}"
+            f"status={getattr(result, 'status_code', '?')} "
+            f"bytes={len(getattr(result, 'text', '') or '')}"
         )
-
-    # Prediction API returns the current pdbUrl (version-agnostic).
-    try:
-        meta = session.get(AFDB_PREDICTION.format(acc=accession), timeout=60)
-        if meta.ok:
-            entries = meta.json()
-            if entries:
-                pdb_url = entries[0].get("pdbUrl") or entries[0].get("pdbFile")
-                if pdb_url:
-                    result = session.get(pdb_url, timeout=120)
-                    if result.ok and _looks_like_pdb(result.text):
-                        return result.text
-    except Exception as exc:
-        print(f"AlphaFold API fetch failed for {accession}: {exc}")
     return None
 
 

--- a/ProteinCartography/fetch_uniprot_metadata.py
+++ b/ProteinCartography/fetch_uniprot_metadata.py
@@ -1,24 +1,29 @@
 #!/usr/bin/env python
+"""Fetch UniProt metadata for aggregated ProteinCartography hits.
+
+Uses UniProt ``/uniprotkb/accessions`` (REST) to avoid the 100-OR search limit,
+with retries and safe handling of empty/null responses.
+"""
+
+from __future__ import annotations
 import argparse
 import os
-import re
+import sys
+import time
 
 import numpy as np
 import pandas as pd
 from api_utils import UniProtWithExpBackoff, session_with_retry
 from constants import UniProtService
 
-# if necessary, mock the `uniprot.search` method (used by `query_uniprot`)
-# see comments in `tests.mocks` for more details
+# If necessary, mock bioservices search (see ``tests.mocks``).
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
     from tests import mocks
 
     mocks.mock_bioservices_uniprot_search()
 
-# only import these functions when using import *
 __all__ = ["query_uniprot"]
 
-# global fields for querying using REST API
 REQUIRED_FIELDS_DICT = {
     "Entry": "accession",
     "Entry Name": "id",
@@ -48,19 +53,20 @@ DEFAULT_FIELDS_DICT = REQUIRED_FIELDS_DICT | OTHER_FIELDS_DICT
 REQUIRED_FIELDS = list(REQUIRED_FIELDS_DICT.values())
 DEFAULT_FIELDS = list(DEFAULT_FIELDS_DICT.values())
 
+UNIPROT_ACCESSIONS = "https://rest.uniprot.org/uniprotkb/accessions"
+BATCH_SIZE = int(os.environ.get("PC_UNIPROT_META_BATCH", "100"))
+RETRIES = int(os.environ.get("PC_UNIPROT_META_RETRIES", "5"))
 
-# parse command line arguments
+
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--input", required=True, help="path of input merged hits file")
+    parser.add_argument("-i", "--input", required=True)
+    parser.add_argument("-o", "--output", required=True)
     parser.add_argument(
-        "-o",
-        "--output",
-        required=True,
-        help="path of destination uniprot_features.tsv file",
-    )
-    parser.add_argument(
-        "-s", "--service", default=UniProtService.BIOSERVICES.value, help="how to fetch metadata"
+        "-s",
+        "--service",
+        default=UniProtService.REST.value,
+        help="How to fetch metadata (rest|bioservices). REST uses /uniprotkb/accessions.",
     )
     parser.add_argument(
         "-a",
@@ -68,160 +74,178 @@ def parse_args():
         nargs="*",
         help="additional non-default fields to fetch from uniprot if using REST",
     )
-    args = parser.parse_args()
-
-    return args
+    return parser.parse_args()
 
 
-def load_existing_data(temp_filepath: str) -> tuple[set, bool]:
-    """
-    Load any existing results from previous incomplete runs, to remove them from the query list.
+def _chunks(items: list[str], size: int):
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
 
-    Args:
-        temp_filepath (str): Path to the temporary file containing previously downloaded entries.
 
-    Returns:
-        tuple:
-        - set: Set of existing entries (accessions) found in the file.
-        - bool: True if header was written (file exists and has data), False otherwise.
-    """
-
-    existing_data = set()
-    header_written = False
-
-    if not os.path.exists(temp_filepath):
-        print(f"{temp_filepath} does not exist. Skipping existing data loading.")
-        return existing_data, header_written
-
-    try:
-        existing_df = pd.read_csv(temp_filepath, sep="\t", usecols=["Entry"])
-        if "Entry" not in existing_df.columns:
-            print(f"No 'Entry' column found in {temp_filepath}. Skipping existing data loading.")
-            return existing_data, header_written
-
-        existing_data = set(existing_df["Entry"].values)
-        print(f"Loaded {len(existing_data)} entries from {temp_filepath}")
-        header_written = True
-
-    except pd.errors.EmptyDataError:
-        print(f"{temp_filepath} is empty. Skipping existing data loading.")
-
-    return existing_data, header_written
+def _fetch_accessions_tsv(session, accessions: list[str], fields_string: str) -> str:
+    """GET /uniprotkb/accessions — avoids the 100-OR search limit."""
+    last_error = None
+    for attempt in range(1, RETRIES + 1):
+        try:
+            response = session.get(
+                UNIPROT_ACCESSIONS,
+                params={
+                    "accessions": ",".join(accessions),
+                    "format": "tsv",
+                    "fields": fields_string,
+                },
+                timeout=120,
+            )
+            if response.status_code == 400:
+                # Invalid ids in the batch — shrink and retry halves if needed.
+                last_error = f"400 Bad Request: {response.text[:200]}"
+                print(
+                    f"[fetch_uniprot_metadata] Bad Request on {len(accessions)} ids "
+                    f"(attempt {attempt}/{RETRIES}): {last_error}",
+                    file=sys.stderr,
+                )
+                if len(accessions) > 1 and attempt < RETRIES:
+                    mid = len(accessions) // 2
+                    left = _fetch_accessions_tsv(session, accessions[:mid], fields_string)
+                    right = _fetch_accessions_tsv(session, accessions[mid:], fields_string)
+                    # Merge TSVs (drop duplicate header from right).
+                    left_lines = left.splitlines()
+                    right_lines = right.splitlines()
+                    if not left_lines:
+                        return right
+                    if not right_lines:
+                        return left
+                    return "\n".join(left_lines + right_lines[1:]) + "\n"
+                time.sleep(min(60, 2 * attempt))
+                continue
+            response.raise_for_status()
+            if not response.text or not response.text.strip():
+                raise RuntimeError("empty UniProt accessions response")
+            return response.text
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            print(
+                f"[fetch_uniprot_metadata] {type(exc).__name__} "
+                f"(n={len(accessions)}, attempt {attempt}/{RETRIES}): {exc}",
+                file=sys.stderr,
+            )
+            time.sleep(min(60, 2 * attempt))
+    raise RuntimeError(
+        f"UniProt accessions fetch failed after {RETRIES} attempts "
+        f"(batch size {len(accessions)}): {last_error}"
+    )
 
 
 def query_uniprot(
     input_file: str,
     output_file: str,
-    batch_size=100,
+    batch_size=None,
     sub_batch_size=100,
     fmt="tsv",
     fields=DEFAULT_FIELDS,
-    service=UniProtService.BIOSERVICES,
+    service=UniProtService.REST,
 ):
-    """
-    Takes an input list of accessions and gets the full information set from Uniprot
-    for those proteins.
-
-    Args:
-        input_file (str): path to a text file of accessions (with one accession per line)
-        output_file (str): path of destination tsv file with all uniprot features
-        batch_size (int): number of entries to query per batch.
-        sub_batch_size (int): number of entries to pull per page of batch.
-        fmt (str): output suffix format (default 'tsv')
-        fields (list): list of UniProt fields to retrieve.
-        service (str): which API to use: 'rest' or 'bioservices'.
-
-    Returns:
-        a pandas.DataFrame of the resulting features
-    """
-
+    """Download UniProt metadata for one accession per input line."""
+    batch_size = int(batch_size or BATCH_SIZE)
     temp_filepath = output_file + ".temp"
 
     if os.path.exists(output_file):
         print("Output file already exists at this location. Aborting.")
         return
 
-    existing_data, header_written = load_existing_data(temp_filepath)
-
-    # Define regular expression pattern to extract the next URL from the response headers
-    re_next_link = re.compile(r'<(.+)>; rel="next"')
-
-    session = session_with_retry()
-
-    def get_next_link(headers):
-        # Extract the next URL from the "Link" header if present
-        if "Link" in headers:
-            match = re_next_link.match(headers["Link"])
-            if match:
-                return match.group(1)
+    header_written = False
+    existing_data = set()
+    if os.path.exists(temp_filepath):
+        try:
+            existing_df = pd.read_csv(temp_filepath, sep="\t", usecols=["Entry"])
+            if "Entry" in existing_df.columns:
+                existing_data = set(existing_df["Entry"].values)
+                print(f"Loaded {len(existing_data)} entries from {temp_filepath}")
+                header_written = True
+            else:
+                print(f"No 'Entry' column found in {temp_filepath}. Skipping existing data.")
+        except pd.errors.EmptyDataError:
+            print(f"{temp_filepath} is empty. Skipping existing data loading.")
 
     fields_string = ",".join(fields)
-
-    def get_batch(query_string: str):
-        # Generator function to fetch data in batches
-        if service == UniProtService.REST:
-            batch_url = f"https://rest.uniprot.org/uniprotkb/search?query={query_string}&format={fmt}&fields={fields_string}&size={sub_batch_size}"
-            while batch_url:
-                response = session.get(batch_url)
-                response.raise_for_status()
-                yield response.text
-                batch_url = get_next_link(response.headers)
-        elif service == UniProtService.BIOSERVICES:
-            uniprot = UniProtWithExpBackoff()
-            results = uniprot.search(
-                query_string, columns=fields_string, size=sub_batch_size, progress=False
-            )
-            # bioservices doesn't directly return the number of results.
-            yield results
-        else:
-            raise ValueError(f"Unknown service {service}")
+    session = session_with_retry()
 
     with open(input_file) as q:
-        query_accessions = [line.rstrip("\n") for line in q.readlines()]
-        # Remove accessions that have already been downloaded, keeping the order.
-        query_accessions = [e for e in query_accessions if e not in existing_data]
+        query_accessions = [line.rstrip("\n").strip() for line in q.readlines() if line.strip()]
+    query_accessions = [e for e in query_accessions if e not in existing_data]
+    # De-dupe while preserving order.
+    query_accessions = list(dict.fromkeys(query_accessions))
 
-    # Split the query accessions into batches
-    accession_batches = [
-        query_accessions[i : i + batch_size] for i in range(0, len(query_accessions), batch_size)
-    ]
+    accession_batches = list(_chunks(query_accessions, max(1, batch_size)))
+    total = len(query_accessions)
+    print(
+        f"[fetch_uniprot_metadata] fetching {total} accessions via {service} (batch={batch_size})",
+        file=sys.stderr,
+    )
 
-    # Process each batch separately
-    for i, accession_batch in enumerate(accession_batches):
-        print(f">> Starting batch {i + 1} of {len(accession_batches)}")
+    with open(temp_filepath, "a") as temp_file:
+        for i, accession_batch in enumerate(accession_batches):
+            print(f">> Starting batch {i + 1} of {len(accession_batches)}")
+            if service == UniProtService.REST:
+                batch_text = _fetch_accessions_tsv(session, accession_batch, fields_string)
+            elif service == UniProtService.BIOSERVICES:
+                # Keep bioservices available but cap OR count at UniProt's limit.
+                uniprot = UniProtWithExpBackoff()
+                or_batches = list(_chunks(accession_batch, 100))
+                parts = []
+                for sub in or_batches:
+                    query_string = "(" + " OR ".join(f"accession:{a}" for a in sub) + ")"
+                    results = uniprot.search(
+                        query_string, columns=fields_string, size=sub_batch_size, progress=False
+                    )
+                    if results is None:
+                        raise RuntimeError(
+                            f"bioservices UniProt.search returned None for {len(sub)} ids"
+                        )
+                    parts.append(results)
+                # Merge TSV parts
+                lines_out = []
+                for idx, part in enumerate(parts):
+                    plines = part.splitlines()
+                    if not plines:
+                        continue
+                    if idx == 0:
+                        lines_out.extend(plines)
+                    else:
+                        lines_out.extend(plines[1:])
+                batch_text = "\n".join(lines_out) + ("\n" if lines_out else "")
+            else:
+                raise ValueError(f"Unknown service {service}")
 
-        # Construct the query string for the batch
-        query_string = " OR ".join(f"accession:{accession}" for accession in accession_batch)
-        query_string = f"({query_string})"
+            if not batch_text or not batch_text.strip():
+                print(f"empty batch {i + 1}; skipping", file=sys.stderr)
+                continue
 
-        # Construct the URL with the constructed query string
-        progress = 0
-        accessions_in_batch = len(accession_batch)
+            lines = batch_text.splitlines()
+            if not header_written:
+                print_lines = lines
+                header_written = True
+            else:
+                print_lines = lines[1:]
 
-        with open(temp_filepath, "a") as temp_file:
-            for batch in get_batch(query_string):
-                lines = batch.splitlines()
+            for line in print_lines:
+                print(line, file=temp_file)
 
-                if not header_written:
-                    print_lines = lines
-                    header_written = True
-                else:
-                    print_lines = lines[1:]
+            progress = max(0, len(lines) - 1)
+            print(f"downloaded {progress} hits for batch {i + 1} (of {total} total)")
 
-                for line in print_lines:
-                    print(line, file=temp_file)
-
-                progress += len(lines) - 1
-                print(f"downloaded {progress} / {accessions_in_batch} hits for batch {i + 1}")
+    if not os.path.exists(temp_filepath) or os.path.getsize(temp_filepath) == 0:
+        raise RuntimeError(f"no UniProt metadata written for {input_file}")
 
     df = pd.read_csv(temp_filepath, sep="\t")
+    if "Entry" not in df.columns:
+        raise RuntimeError(f"UniProt TSV missing Entry column; columns={list(df.columns)}")
     df.insert(0, "protid", df["Entry"].values)
 
     def lineage_string_splitter(lineage_string):
         if lineage_string is np.nan:
             return np.nan
-        else:
-            return [rank.split(" (")[0] for rank in lineage_string.split(", ")]
+        return [rank.split(" (")[0] for rank in str(lineage_string).split(", ")]
 
     try:
         df["Lineage"] = df["Taxonomic lineage"].apply(lineage_string_splitter)
@@ -230,26 +254,17 @@ def query_uniprot(
 
     df.to_csv(output_file, sep="\t", index=None)
     os.remove(temp_filepath)
-
     return df
 
 
-# run this if called from the interpreter
 def main():
     args = parse_args()
-
-    input_file = args.input
-    output_file = args.output
     service = UniProtService(args.service)
-    additional_fields = args.additional_fields
-
-    fields = DEFAULT_FIELDS
-    if additional_fields is not None:
-        fields += additional_fields
-
-    query_uniprot(input_file, output_file, fields=fields, service=service)
+    fields = list(DEFAULT_FIELDS)
+    if args.additional_fields is not None:
+        fields += args.additional_fields
+    query_uniprot(args.input, args.output, fields=fields, service=service)
 
 
-# check if called from interpreter
 if __name__ == "__main__":
     main()

--- a/ProteinCartography/leiden_clustering.py
+++ b/ProteinCartography/leiden_clustering.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
+"""Leiden clustering over a ProteinCartography TM-score matrix.
+
+For N < 3, assign every protein to a single cluster and skip Scanpy. Otherwise
+clamp ``n_neighbors`` / ``n_pcs`` to valid ranges for the matrix size.
+"""
+
+from __future__ import annotations
 import argparse
 
 import numpy as np
 import pandas as pd
 import scanpy as sc
 
-# only import these functions when using import *
 __all__ = ["scanpy_leiden_cluster"]
 
 
-# parse command line arguments
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -49,6 +54,17 @@ def parse_args():
     return args
 
 
+def _singleton_membership(
+    protids: list[str], cluster_name: str, cluster_abbrev: str
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "protid": protids,
+            cluster_name: [f"{cluster_abbrev}0"] * len(protids),
+        }
+    )
+
+
 def scanpy_leiden_cluster(
     input_file: str,
     savefile=None,
@@ -68,25 +84,33 @@ def scanpy_leiden_cluster(
         n_pcs (int): number of PCs to use for initial PCA.
         **kwargs are passed to `sc.pp.neighbors()`.
     """
-    # Load the data
     adata = sc.read_csv(input_file, delimiter="\t")
+    n = int(adata.n_obs)
+    if n < 3:
+        print(
+            f"[leiden_clustering] N={n} too small for Leiden; "
+            f"assigning all proteins to {cluster_abbrev}0"
+        )
+        membership = _singleton_membership(list(adata.obs_names), cluster_name, cluster_abbrev)
+        if savefile is not None:
+            membership.to_csv(savefile, sep="\t", index=None)
+        return membership
 
-    # Run intial PCA
     sc.tl.pca(adata, svd_solver="arpack")
 
-    n_neighbors_recommended = int(np.round(len(adata.var) / 10))
-    if n_neighbors_recommended > n_neighbors:
-        n_neighbors_used = n_neighbors_recommended
-    else:
-        n_neighbors_used = n_neighbors
+    n_neighbors = int(n_neighbors)
+    n_pcs = int(n_pcs)
+    n_neighbors_recommended = int(np.round(n / 10))
+    n_neighbors_used = max(n_neighbors, n_neighbors_recommended)
+    # Scanpy requires 1 < n_neighbors <= N - 1 for a connected graph.
+    n_neighbors_used = max(2, min(n_neighbors_used, n - 1))
+    max_pcs = max(1, min(n - 1, adata.n_vars - 1 if adata.n_vars > 1 else 1))
+    n_pcs_used = max(1, min(n_pcs, max_pcs))
 
-    # Run nearest neighbors, umap, then leiden
-    # We should probably determine a good empirical default for this
-    sc.pp.neighbors(adata, n_neighbors=n_neighbors_used, n_pcs=n_pcs, **kwargs)
+    sc.pp.neighbors(adata, n_neighbors=n_neighbors_used, n_pcs=n_pcs_used, **kwargs)
     sc.tl.umap(adata)
     sc.tl.leiden(adata)
 
-    # Extract leiden cluster assignment
     membership = pd.DataFrame(adata.obs["leiden"]).reset_index()
     membership.rename(columns={"index": "protid", "leiden": cluster_name}, inplace=True)
     max_chars = len(str(membership[cluster_name].astype(int).max()))
@@ -100,26 +124,20 @@ def scanpy_leiden_cluster(
     return membership
 
 
-# run this if called from the interpreter
 def main():
     args = parse_args()
-    input_file = args.input
-    output_file = args.output
-    neighbors = int(args.n_neighbors)
-    pcs = int(args.n_pcs)
-    cluster_name = args.cluster_name
-    cluster_abbrev = args.cluster_abbrev
+    n_neighbors = int(args.n_neighbors)
+    n_pcs = int(args.n_pcs)
 
     scanpy_leiden_cluster(
-        input_file=input_file,
-        savefile=output_file,
-        n_neighbors=neighbors,
-        n_pcs=pcs,
-        cluster_name=cluster_name,
-        cluster_abbrev=cluster_abbrev,
+        args.input,
+        args.output,
+        n_neighbors=n_neighbors,
+        n_pcs=n_pcs,
+        cluster_name=args.cluster_name,
+        cluster_abbrev=args.cluster_abbrev,
     )
 
 
-# check if called from interpreter
 if __name__ == "__main__":
     main()

--- a/ProteinCartography/map_refseq_ids.py
+++ b/ProteinCartography/map_refseq_ids.py
@@ -117,7 +117,8 @@ def _fetch_results(session, job_id: str) -> list[dict]:
     stream = session.get(f"{UNIPROT_IDMAPPING_API}/stream/{job_id}")
     stream.raise_for_status()
     payload = stream.json()
-    return list(payload.get("results") or [])
+    raw = payload.get("results") or []
+    return list(raw) if isinstance(raw, list) else []
 
 
 def _map_batch(session, db: str, batch: list[str]) -> list[dict]:
@@ -141,8 +142,11 @@ def _map_batch(session, db: str, batch: list[str]) -> list[dict]:
                 )
                 sleep(min(60, POLL_SECONDS * attempt * 2))
                 continue
-            if "results" in status:
-                return list(status.get("results") or [])
+            raw = status.get("results")
+            # Status payloads sometimes include a non-list "results" sentinel.
+            # Only treat a real list as the mapped rows; otherwise fetch /stream.
+            if isinstance(raw, list):
+                return raw
             return _fetch_results(session, job_id)
         except Exception as exc:  # noqa: BLE001 — retry transient API/transport failures
             last_error = exc

--- a/ProteinCartography/map_refseq_ids.py
+++ b/ProteinCartography/map_refseq_ids.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python
+"""Map RefSeq / EMBL CDS accessions to UniProtKB.
+
+Handles UniProt idmapping status correctly (303 redirect / FINISHED / ERROR),
+batches large ID lists, and retries transient ``jobStatus: ERROR`` responses.
+"""
+
+from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from time import sleep
 
 import pandas as pd
@@ -11,8 +19,7 @@ from api_utils import (
 )
 from constants import UniProtService
 
-# If necessary, mock the `uniprot.mapping` method (used by `map_refseqids_bioservices`).
-# See comments in `tests.mocks` for more details.
+# If necessary, mock bioservices mapping (see ``tests.mocks``).
 if os.environ.get("PROTEINCARTOGRAPHY_WAS_CALLED_BY_PYTEST") == "true":
     from tests import mocks
 
@@ -20,191 +27,191 @@ if os.environ.get("PROTEINCARTOGRAPHY_WAS_CALLED_BY_PYTEST") == "true":
 
 __all__ = ["map_refseqids_bioservices", "map_refseqids_rest"]
 
-# The default databases to query.
 DEFAULT_DBS = ["EMBL-GenBank-DDBJ_CDS", "RefSeq_Protein"]
+UNIPROT_IDMAPPING_API = "https://rest.uniprot.org/idmapping"
 
-UNIPROT_IDMAPPING_API_URL = "https://rest.uniprot.org/idmapping"
-
-# Time in seconds to wait between job status checks.
-SLEEP_TIME_BETWEEN_JOB_STATUS_CHECKS = 30
-
-# Allow a generous number of status checks because sometimes the UniProt ID Mapping API is slow.
-MAX_NUM_JOB_STATUS_CHECKS = 100
+# Per-batch polling. Override via env.
+BATCH_SIZE = int(os.environ.get("PC_UNIPROT_MAP_BATCH", "500"))
+MAX_WAIT_SECONDS = int(os.environ.get("PC_UNIPROT_MAP_TIMEOUT", "1800"))
+POLL_SECONDS = float(os.environ.get("PC_UNIPROT_MAP_POLL", "10"))
+SUBMIT_RETRIES = int(os.environ.get("PC_UNIPROT_MAP_RETRIES", "5"))
 
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-i",
-        "--input",
-        required=True,
-        help="File path to the input text file containing one accession per line.",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        required=True,
-        help="File path to the output text file of uniquely-mapped Uniprot accessions.",
-    )
-    parser.add_argument(
-        "-d",
-        "--databases",
-        nargs="+",
-        default=DEFAULT_DBS,
-        help=f"The databases to use for mapping. Defaults to {DEFAULT_DBS}",
-    )
-    parser.add_argument(
-        "-s", "--service", default=UniProtService.REST.value, help="How to fetch the mapping."
-    )
-    args = parser.parse_args()
-    return args
+    parser.add_argument("-i", "--input", required=True)
+    parser.add_argument("-o", "--output", required=True)
+    parser.add_argument("-d", "--databases", nargs="+", default=DEFAULT_DBS)
+    parser.add_argument("-s", "--service", default=UniProtService.REST.value)
+    return parser.parse_args()
 
 
 def map_refseqids_bioservices(
     input_file: str, output_file: str, query_dbs: list, return_full=False
 ):
-    """
-    Takes an input .txt file of accessions and maps to UniProt accessions using `bioservices`.
-
-    Args:
-        input_file (str): path to input .txt file containing one accession per line.
-        output_file (str): path to destination .txt file.
-        query_dbs (list): list of valid databases to query using the Uniprot ID mapping API.
-            Each database will be queried individually.
-            The results are compiled and unique results are printed to output_file.
-    """
-
     uniprot = UniProtWithExpBackoff()
-
     with open(input_file) as f:
         ids = f.read().splitlines()
+    ids = ids[:100000]
 
-    # Limit the number of ids to prevent the uniprot mapping API from timing out.
-    max_num_ids = 100000
-    ids = ids[:max_num_ids]
-
-    all_results_df = pd.DataFrame()
-
-    for query_db in query_dbs:
-        results = uniprot.mapping(query_db, "UniProtKB", query=",".join(ids))
+    dummy_df = pd.DataFrame()
+    for i, db in enumerate(query_dbs):
+        results = uniprot.mapping(
+            db, "UniProtKB", query=",".join(ids), max_waiting_time=MAX_WAIT_SECONDS
+        )
+        if not results or "results" not in results:
+            continue
         results_df = pd.json_normalize(results["results"])
-
-        # If there are no results, skip to the next database.
         if len(results_df) == 0:
             continue
+        dummy_df = (
+            results_df if i == 0 or dummy_df.empty else pd.concat([dummy_df, results_df], axis=0)
+        )
 
-        all_results_df = pd.concat([all_results_df, results_df], axis=0)
-
-    # Extract just the unique Uniprot accessions.
-    hits = all_results_df["to.primaryAccession"].unique()
-
-    # Save those accessions to a .txt file.
+    hits = (
+        dummy_df["to.primaryAccession"].unique()
+        if not dummy_df.empty and "to.primaryAccession" in dummy_df.columns
+        else []
+    )
     with open(output_file, "w+") as f:
         f.writelines(hit + "\n" for hit in hits)
-
     if return_full:
-        return all_results_df
+        return dummy_df
+
+
+def _chunks(items: list[str], size: int):
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def _poll_job(session, job_id: str) -> dict:
+    """Wait until UniProt finishes (303 / FINISHED / results) or errors."""
+    deadline = time.time() + MAX_WAIT_SECONDS
+    last_status = None
+    while time.time() < deadline:
+        response = session.get(
+            f"{UNIPROT_IDMAPPING_API}/status/{job_id}",
+            allow_redirects=False,
+        )
+        # Finished jobs redirect to the results collection.
+        if response.status_code in (303, 302):
+            return {"jobStatus": "FINISHED"}
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        last_status = payload
+        status = payload.get("jobStatus")
+        if status == "FINISHED" or "results" in payload:
+            return payload if "results" in payload else {"jobStatus": "FINISHED"}
+        if status == "ERROR":
+            return payload
+        sleep(POLL_SECONDS)
+    raise TimeoutError(
+        f"UniProt idmapping job {job_id} did not finish within {MAX_WAIT_SECONDS}s; "
+        f"last status={last_status}"
+    )
+
+
+def _fetch_results(session, job_id: str) -> list[dict]:
+    stream = session.get(f"{UNIPROT_IDMAPPING_API}/stream/{job_id}")
+    stream.raise_for_status()
+    payload = stream.json()
+    return list(payload.get("results") or [])
+
+
+def _map_batch(session, db: str, batch: list[str]) -> list[dict]:
+    """Submit one batch with retries on UniProt-side ERROR / transport flakes."""
+    last_error = None
+    for attempt in range(1, SUBMIT_RETRIES + 1):
+        try:
+            ticket = session.post(
+                f"{UNIPROT_IDMAPPING_API}/run",
+                {"ids": ",".join(batch), "from": db, "to": "UniProtKB"},
+            )
+            ticket.raise_for_status()
+            job_id = ticket.json()["jobId"]
+            status = _poll_job(session, job_id)
+            if status.get("jobStatus") == "ERROR":
+                last_error = status.get("errors") or status
+                print(
+                    f"[map_refseq_ids] UniProt ERROR on {db} batch "
+                    f"(n={len(batch)}, attempt {attempt}/{SUBMIT_RETRIES}): {last_error}",
+                    file=sys.stderr,
+                )
+                sleep(min(60, POLL_SECONDS * attempt * 2))
+                continue
+            if "results" in status:
+                return list(status.get("results") or [])
+            return _fetch_results(session, job_id)
+        except Exception as exc:  # noqa: BLE001 — retry transient API/transport failures
+            last_error = exc
+            print(
+                f"[map_refseq_ids] {type(exc).__name__} on {db} batch "
+                f"(n={len(batch)}, attempt {attempt}/{SUBMIT_RETRIES}): {exc}",
+                file=sys.stderr,
+            )
+            sleep(min(60, POLL_SECONDS * attempt * 2))
+    raise RuntimeError(
+        f"UniProt idmapping failed for {db} after {SUBMIT_RETRIES} attempts "
+        f"(batch size {len(batch)}): {last_error}"
+    )
 
 
 def map_refseqids_rest(input_file: str, output_file: str, query_dbs: list, return_full=False):
-    """
-    Takes an input .txt file of accessions and maps to UniProt accessions
-    using the Uniprot ID mapping REST API.
-
-    Args:
-        input_file (str): path to input .txt file containing one accession per line.
-        output_file (str): path to destination .txt file.
-        query_dbs (list): list of valid databases to query using the Uniprot ID mapping API.
-            Each database will be queried individually.
-            The results are compiled and unique results are printed to output_file.
-        return_full (bool): whether to return all of the results as a dataframe
-
-    For reference, here is an example curl POST request using the REST API:
-    ```
-    curl --request POST 'https://rest.uniprot.org/idmapping/run' \
-      --form 'ids="P21802,P12345"' \
-      --form 'from="UniProtKB_AC-ID"' \
-      --form 'to="UniRef90"'
-    ```
-    """
     with open(input_file) as f:
-        input_lines = f.read().splitlines()
-        input_ids = list(set(input_lines))
-        input_string = ",".join(input_ids)
+        input_ids = list(dict.fromkeys(line.strip() for line in f if line.strip()))
 
-    all_results_df = pd.DataFrame()
+    if not input_ids:
+        print("[map_refseq_ids] empty input — writing empty UniProt hit list", file=sys.stderr)
+        with open(output_file, "w+") as f:
+            pass
+        if return_full:
+            return pd.DataFrame()
+        return
 
-    for query_db in query_dbs:
-        print(f"Mapping database '{query_db}' to UniProtKB")
+    session = session_with_retry()
+    frames: list[pd.DataFrame] = []
 
-        submission_response = (
-            session_with_retry()
-            .post(
-                f"{UNIPROT_IDMAPPING_API_URL}/run",
-                {"ids": input_string, "from": query_db, "to": "UniProtKB"},
-            )
-            .json()
+    for db in query_dbs:
+        print(
+            f"[map_refseq_ids] mapping {len(input_ids)} ids via {db} "
+            f"(batch={BATCH_SIZE}, timeout={MAX_WAIT_SECONDS}s)",
+            file=sys.stderr,
         )
+        rows: list[dict] = []
+        for batch in _chunks(input_ids, max(1, BATCH_SIZE)):
+            rows.extend(_map_batch(session, db, batch))
+        if not rows:
+            continue
+        frames.append(pd.DataFrame(rows))
 
-        print(f"Submission response for mapping request from {query_db} to UniProtKB:")
-        print(submission_response)
+    dummy_df = pd.concat(frames, axis=0) if frames else pd.DataFrame()
+    if dummy_df.empty:
+        hits = []
+    elif "to" in dummy_df.columns:
+        hits = dummy_df["to"].dropna().unique()
+    elif "to.primaryAccession" in dummy_df.columns:
+        hits = dummy_df["to.primaryAccession"].dropna().unique()
+    else:
+        hits = []
 
-        job_id = submission_response["jobId"]
-
-        # Poll until the job is successful or we time out.
-        num_tries = 0
-        while num_tries < MAX_NUM_JOB_STATUS_CHECKS:
-            status_response = (
-                session_with_retry().get(f"{UNIPROT_IDMAPPING_API_URL}/status/{job_id}").json()
-            )
-            num_tries += 1
-
-            # The status response is supposed to include a "jobStatus" key, but anecdotally,
-            # this is only true while the job is running. Once the job is complete,
-            # there is instead a "results" key.
-            job_is_complete = (
-                status_response.get("results") is not None
-                or status_response.get("jobStatus", "").lower() == "finished"
-            )
-
-            if job_is_complete:
-                print(f"Job is complete after {num_tries * SLEEP_TIME_BETWEEN_JOB_STATUS_CHECKS}s")
-                break
-
-            sleep(SLEEP_TIME_BETWEEN_JOB_STATUS_CHECKS)
-
-        if num_tries == MAX_NUM_JOB_STATUS_CHECKS:
-            sys.exit(
-                f"The mapping request failed to complete after "
-                f"{num_tries * SLEEP_TIME_BETWEEN_JOB_STATUS_CHECKS}s."
-            )
-
-        results_response = (
-            session_with_retry().get(f"{UNIPROT_IDMAPPING_API_URL}/stream/{job_id}").json()
-        )
-
-        results_df = pd.DataFrame(results_response["results"])
-        all_results_df = pd.concat([all_results_df, results_df], axis=0)
-
-    # Extract just the unique Uniprot accessions and save them to a .txt file.
-    hits = all_results_df["to"].unique()
     with open(output_file, "w+") as f:
-        f.writelines(hit + "\n" for hit in hits)
+        f.writelines(f"{hit}\n" for hit in hits)
 
     if return_full:
-        return all_results_df
+        return dummy_df
 
 
 def main():
     args = parse_args()
-
     service = UniProtService(args.service)
     if service == UniProtService.BIOSERVICES:
-        map_refseqids_bioservices(
-            input_file=args.input, output_file=args.output, query_dbs=args.databases
-        )
+        map_refseqids_bioservices(args.input, args.output, args.databases)
     elif service == UniProtService.REST:
-        map_refseqids_rest(input_file=args.input, output_file=args.output, query_dbs=args.databases)
+        map_refseqids_rest(args.input, args.output, args.databases)
+    else:
+        sys.exit(f"unknown UniProt service: {args.service}")
 
 
 if __name__ == "__main__":

--- a/ProteinCartography/run_blast.py
+++ b/ProteinCartography/run_blast.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python
+"""Run BLAST for a ProteinCartography search-mode seed.
+
+``blast_utils`` defaults to NCBI's WWW/QBlast URL API (``PC_BLAST_BACKEND=www``)
+and writes the same tabular TSV ProteinCartography expects. Soft-fail
+(``PC_BLAST_SOFT_FAIL=1``) lets Foldseek-only maps complete if NCBI is down;
+set ``0`` for hard failure. Legacy ``blastp -remote`` remains available via
+``PC_BLAST_BACKEND=remote``.
+"""
+
+from __future__ import annotations
 import argparse
 import os
 import sys
+from pathlib import Path
 
 import blast_utils
 import constants
 
-# if necessary, mock the `run_blast` method
-# see comments in `tests.mocks` for more details
+# If necessary, mock ``run_blast`` (see ``tests.mocks``).
 if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
     from tests import mocks
 
@@ -15,10 +25,6 @@ if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
 
 
 def parse_args():
-    """
-    Define CLI arguments for the subset of `blastp` arguments that are used by the `run_blast` rule
-    following the nomenclature of the `blastp` CLI
-    """
     parser = argparse.ArgumentParser()
     parser.add_argument("--query", required=True, help="path to the input peptide FASTA file.")
     parser.add_argument(
@@ -59,9 +65,21 @@ def parse_args():
         type=float,
         required=True,
     )
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    return args
+
+def _soft_fail_enabled() -> bool:
+    return os.environ.get("PC_BLAST_SOFT_FAIL", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _write_empty_results(path: str) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("")
 
 
 def main():
@@ -69,12 +87,18 @@ def main():
 
     num_tries = 0
     max_num_tries = args.num_attempts
+    # Optional hard cap so a hanging NCBI call does not burn num_attempts × timeout.
+    cap = os.environ.get("PC_BLAST_MAX_ATTEMPTS", "").strip()
+    if cap.isdigit() and int(cap) > 0:
+        max_num_tries = min(max_num_tries, int(cap))
+    result = None
     while num_tries < max_num_tries:
         word_size = args.word_size if num_tries == 0 else args.word_size_backoff
 
         print(
-            f"Attempt {num_tries + 1}/{max_num_tries} to call blastp "
-            f"(using word size of {word_size})"
+            f"[blast] Attempt {num_tries + 1}/{max_num_tries} to call blastp "
+            f"(using word size of {word_size})",
+            flush=True,
         )
         result = blast_utils.run_blast(
             query=args.query,
@@ -84,15 +108,38 @@ def main():
             word_size=word_size,
             evalue=args.evalue,
         )
-        if result.returncode == 0:
+        if result is None:
+            result = blast_utils.BlastResult(
+                returncode=1,
+                stdout=b"",
+                stderr=b"[blast] run_blast returned None\n",
+            )
+        if result.returncode == 0 and Path(args.out).exists() and Path(args.out).stat().st_size > 0:
             sys.exit(0)
-        else:
-            num_tries += 1
+        if result.returncode == 0 and Path(args.out).exists():
+            # Successful call but zero hits — still a valid empty TSV for extract.
+            print("[blast] blastp returned no hits (empty results file)", flush=True)
+            sys.exit(0)
+        num_tries += 1
+        err = ""
+        if result is not None and result.stderr:
+            err = result.stderr.decode("utf-8", errors="replace")[-300:]
+        print(f"[blast] attempt failed rc={getattr(result, 'returncode', '?')}: {err}", flush=True)
 
-    if num_tries >= max_num_tries:
-        sys.exit(
-            f"BLAST failed after {max_num_tries} tries. The last error message was: {result.stderr}"
+    if _soft_fail_enabled():
+        _write_empty_results(args.out)
+        print(
+            f"[blast] SOFT FAIL after {max_num_tries} tries — writing empty {args.out} "
+            f"and continuing (Foldseek hits still drive the map). "
+            f"Last error: {getattr(result, 'stderr', b'')[-200:]!r}",
+            flush=True,
         )
+        sys.exit(0)
+
+    sys.exit(
+        f"BLAST failed after {max_num_tries} tries. "
+        f"The last error message was: {getattr(result, 'stderr', b'')}"
+    )
 
 
 if __name__ == "__main__":

--- a/ProteinCartography/run_blast.py
+++ b/ProteinCartography/run_blast.py
@@ -68,15 +68,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def _soft_fail_enabled() -> bool:
-    return os.environ.get("PC_BLAST_SOFT_FAIL", "0").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
-
 def _write_empty_results(path: str) -> None:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     Path(path).write_text("")
@@ -117,16 +108,19 @@ def main():
         if result.returncode == 0 and Path(args.out).exists() and Path(args.out).stat().st_size > 0:
             sys.exit(0)
         if result.returncode == 0 and Path(args.out).exists():
-            # Successful call but zero hits — still a valid empty TSV for extract.
+            # Empty TSV is not a successful map unless soft-fail is on.
+            # Otherwise extract_blast_hits would raise after this rule already
+            # exited 0, which aborts Snakemake one step later.
             print("[blast] blastp returned no hits (empty results file)", flush=True)
-            sys.exit(0)
+            if constants.blast_soft_fail_enabled():
+                sys.exit(0)
         num_tries += 1
         err = ""
         if result is not None and result.stderr:
             err = result.stderr.decode("utf-8", errors="replace")[-300:]
         print(f"[blast] attempt failed rc={getattr(result, 'returncode', '?')}: {err}", flush=True)
 
-    if _soft_fail_enabled():
+    if constants.blast_soft_fail_enabled():
         _write_empty_results(args.out)
         print(
             f"[blast] SOFT FAIL after {max_num_tries} tries — writing empty {args.out} "

--- a/ProteinCartography/tests/mocks.py
+++ b/ProteinCartography/tests/mocks.py
@@ -93,11 +93,17 @@ def mock_response(method, url, **_):
     elif url.startswith("https://search.foldseek.com/api"):
         return mock_foldseek_api_responses(method, url)
 
-    # Requests to the UniProtKB REST API.
-    elif url.startswith("https://rest.uniprot.org/uniprotkb/search"):
+    # Requests to the UniProtKB REST API (search *or* /uniprotkb/accessions).
+    elif url.startswith("https://rest.uniprot.org/uniprotkb/search") or url.startswith(
+        "https://rest.uniprot.org/uniprotkb/accessions"
+    ):
         return mock_uniprotkb_rest_api_responses()
 
-    # Requests to the alphafold API.
+    # AlphaFold prediction API (isoform-correct pdbUrl, then files download).
+    elif url.startswith("https://alphafold.ebi.ac.uk/api/prediction"):
+        return mock_alphafold_prediction_api_responses(url)
+
+    # Requests to the alphafold files API.
     elif url.startswith("https://alphafold.ebi.ac.uk/files"):
         return mock_alphafold_files_api_responses(url)
 
@@ -203,6 +209,7 @@ def mock_uniprotkb_rest_api_responses():
 
     mock_response = mock.Mock(spec=requests.Response)
     mock_response.status_code = 200
+    mock_response.ok = True
 
     # Define an empty header, specifically one without a 'Link' key
     # to prevent `fetch_uniprot_metadata.query_uniprot` from requesting a second batch of results.
@@ -216,19 +223,32 @@ def mock_uniprotkb_rest_api_responses():
     return mock_response
 
 
+def mock_alphafold_prediction_api_responses(url):
+    """Return a pdbUrl that the files mock can serve (canonical F1 v6 path)."""
+    accession = url.rstrip("/").split("/")[-1].split("?")[0]
+    mock_response = mock.Mock(spec=requests.Response)
+    mock_response.status_code = 200
+    mock_response.ok = True
+    mock_response.json.return_value = [
+        {"pdbUrl": f"https://alphafold.ebi.ac.uk/files/AF-{accession}-F1-model_v6.pdb"}
+    ]
+    return mock_response
+
+
 def mock_alphafold_files_api_responses(url):
     """
     Mock the response to calls made to the AlphaFold API to download PDB files.
     """
 
-    # Parse the accession from the url.
-    result = re.findall(r"AF-([A-Z0-9]+)-F1-model_v6\.pdb", url)
-    if result is None:
-        raise ValueError("Unexpected url: {url}")
+    # Parse the accession from the url. Isoform ids look like AF-Q9Y6V0-3-F1-...
+    result = re.findall(r"AF-([A-Z0-9]+)(?:-\d+)?-F1-model_v[46]\.pdb", url)
+    if not result:
+        raise ValueError(f"Unexpected url: {url}")
     accession = result[0]
 
     mock_response = mock.Mock(spec=requests.Response)
     mock_response.status_code = 200
+    mock_response.ok = True
 
     # The AlphaFold URL requests v6 files, but the test artifacts contain v4 files.
     # Because we can safely use the "old" v4 files for testing purposes,

--- a/ProteinCartography/tests/test_blast_utils.py
+++ b/ProteinCartography/tests/test_blast_utils.py
@@ -1,0 +1,51 @@
+"""Unit tests for blast_utils WWW XML → TSV conversion."""
+
+from __future__ import annotations
+import pathlib
+
+import blast_utils
+
+
+def test_xml_to_blast_tsv_writes_sacc(tmp_path: pathlib.Path):
+    xml = """<?xml version="1.0"?>
+<BlastOutput>
+  <BlastOutput_query-def>P07338</BlastOutput_query-def>
+  <BlastOutput_iterations>
+    <Iteration>
+      <Iteration_hits>
+        <Hit>
+          <Hit_id>ref|NP_001234.1|</Hit_id>
+          <Hit_accession>NP_001234</Hit_accession>
+          <Hit_def>example protein</Hit_def>
+          <Hit_hsps>
+            <Hsp>
+              <Hsp_bit-score>100</Hsp_bit-score>
+              <Hsp_evalue>1e-20</Hsp_evalue>
+              <Hsp_query-from>1</Hsp_query-from>
+              <Hsp_query-to>50</Hsp_query-to>
+              <Hsp_hit-from>1</Hsp_hit-from>
+              <Hsp_hit-to>50</Hsp_hit-to>
+              <Hsp_identity>45</Hsp_identity>
+              <Hsp_gaps>0</Hsp_gaps>
+              <Hsp_align-len>50</Hsp_align-len>
+            </Hsp>
+          </Hit_hsps>
+        </Hit>
+      </Iteration_hits>
+    </Iteration>
+  </BlastOutput_iterations>
+</BlastOutput>
+"""
+    out = tmp_path / "blast.tsv"
+    n = blast_utils._xml_to_blast_tsv(xml, str(out))
+    assert n == 1
+    line = out.read_text().strip().split("\t")
+    assert line[0] == "P07338"
+    assert "NP_001234" in line  # sacc column
+
+
+def test_xml_to_blast_tsv_empty_without_blast_output(tmp_path: pathlib.Path):
+    out = tmp_path / "empty.tsv"
+    n = blast_utils._xml_to_blast_tsv("<html>waiting</html>", str(out))
+    assert n == 0
+    assert out.read_text() == ""

--- a/ProteinCartography/tests/test_extract_blast_hits.py
+++ b/ProteinCartography/tests/test_extract_blast_hits.py
@@ -1,12 +1,30 @@
-"""Unit tests for empty BLAST hit extraction."""
+"""Unit tests for BLAST hit extraction."""
 
 from __future__ import annotations
 import pathlib
 
+import constants
 import extract_blast_hits
+import pytest
 
 
-def test_extract_blast_hits_empty_input_writes_empty_file(tmp_path: pathlib.Path):
+def test_extract_blast_hits_empty_hard_fails_by_default(tmp_path: pathlib.Path):
+    infile = tmp_path / "blast.tsv"
+    outfile = tmp_path / "hits.txt"
+    infile.write_text("")
+    with pytest.raises(Exception, match="No hits were returned"):
+        extract_blast_hits.extract_blast_hits(
+            str(infile),
+            str(outfile),
+            column_names=["qseqid", "sacc"],
+        )
+    assert outfile.read_text() == ""
+
+
+def test_extract_blast_hits_empty_soft_fail(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PC_BLAST_SOFT_FAIL", "1")
     infile = tmp_path / "blast.tsv"
     outfile = tmp_path / "hits.txt"
     infile.write_text("")
@@ -29,3 +47,12 @@ def test_extract_blast_hits_reads_sacc(tmp_path: pathlib.Path):
     )
     hits = outfile.read_text().splitlines()
     assert hits == ["NP_1", "NP_2"]
+
+
+def test_soft_fail_flag_is_opt_in_only(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("PC_BLAST_SOFT_FAIL", raising=False)
+    assert constants.blast_soft_fail_enabled() is False
+    monkeypatch.setenv("PC_BLAST_SOFT_FAIL", "1")
+    assert constants.blast_soft_fail_enabled() is True
+    monkeypatch.setenv("PC_BLAST_SOFT_FAIL", "maybe")
+    assert constants.blast_soft_fail_enabled() is False

--- a/ProteinCartography/tests/test_extract_blast_hits.py
+++ b/ProteinCartography/tests/test_extract_blast_hits.py
@@ -1,0 +1,31 @@
+"""Unit tests for empty BLAST hit extraction."""
+
+from __future__ import annotations
+import pathlib
+
+import extract_blast_hits
+
+
+def test_extract_blast_hits_empty_input_writes_empty_file(tmp_path: pathlib.Path):
+    infile = tmp_path / "blast.tsv"
+    outfile = tmp_path / "hits.txt"
+    infile.write_text("")
+    extract_blast_hits.extract_blast_hits(
+        str(infile),
+        str(outfile),
+        column_names=["qseqid", "sacc"],
+    )
+    assert outfile.read_text() == ""
+
+
+def test_extract_blast_hits_reads_sacc(tmp_path: pathlib.Path):
+    infile = tmp_path / "blast.tsv"
+    outfile = tmp_path / "hits.txt"
+    infile.write_text("q1\tNP_1\nq1\tNP_2\nq1\tNP_1\n")
+    extract_blast_hits.extract_blast_hits(
+        str(infile),
+        str(outfile),
+        column_names=["qseqid", "sacc"],
+    )
+    hits = outfile.read_text().splitlines()
+    assert hits == ["NP_1", "NP_2"]

--- a/ProteinCartography/tests/test_fetch_accession.py
+++ b/ProteinCartography/tests/test_fetch_accession.py
@@ -1,0 +1,64 @@
+"""Unit tests for AlphaFold PDB fetch (isoform URLs + no error-body writes)."""
+
+from __future__ import annotations
+import pathlib
+import sys
+from unittest.mock import MagicMock, Mock
+
+sys.modules.setdefault("bioservices", MagicMock())
+
+import fetch_accession  # noqa: E402
+
+
+class _FakeResponse:
+    def __init__(self, *, ok=True, status_code=200, text="", json_data=None):
+        self.ok = ok
+        self.status_code = status_code
+        self.text = text
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+def test_fetch_pdb_uses_isoform_pdburl(tmp_path: pathlib.Path):
+    pdb_body = "ATOM      1  N   ALA A   1      11.104  13.207  10.000  1.00 80.00\n"
+    isoform_url = "https://alphafold.ebi.ac.uk/files/AF-Q9Y6V0-3-F1-model_v6.pdb"
+    guessed_f1 = "https://alphafold.ebi.ac.uk/files/AF-Q9Y6V0-F1-model_v6.pdb"
+
+    def fake_get(url, timeout=None):
+        if "api/prediction/Q9Y6V0" in url:
+            return _FakeResponse(json_data=[{"pdbUrl": isoform_url}])
+        if url == isoform_url:
+            return _FakeResponse(text=pdb_body)
+        if url == guessed_f1:
+            return _FakeResponse(ok=False, status_code=404, text="<Error>NoSuchKey</Error>")
+        raise AssertionError(f"unexpected url {url}")
+
+    session = Mock()
+    session.get.side_effect = fake_get
+
+    fetch_accession.fetch_pdb("Q9Y6V0", str(tmp_path), session=session)
+    out = tmp_path / "Q9Y6V0.pdb"
+    assert out.read_text() == pdb_body
+    assert "<Error>" not in out.read_text()
+
+
+def test_fetch_pdb_does_not_write_error_xml(tmp_path: pathlib.Path):
+    error = "<Error>NoSuchKey</Error>"
+
+    def fake_get(url, timeout=None):
+        if "api/prediction" in url:
+            return _FakeResponse(ok=False, status_code=404, text=error)
+        return _FakeResponse(ok=False, status_code=404, text=error)
+
+    session = Mock()
+    session.get.side_effect = fake_get
+
+    fetch_accession.fetch_pdb("Q9Y6V0", str(tmp_path), session=session)
+    assert not (tmp_path / "Q9Y6V0.pdb").exists()
+
+
+def test_looks_like_pdb_rejects_error_body():
+    assert fetch_accession._looks_like_pdb("<Error>NoSuchKey</Error>") is False
+    assert fetch_accession._looks_like_pdb("ATOM      1  N") is True

--- a/ProteinCartography/tests/test_run_blast.py
+++ b/ProteinCartography/tests/test_run_blast.py
@@ -1,0 +1,64 @@
+"""Unit tests for run_blast empty-result handling."""
+
+from __future__ import annotations
+import pathlib
+import sys
+
+import blast_utils
+import pytest
+import run_blast
+
+
+def _argv(tmp_path: pathlib.Path, out: pathlib.Path) -> list[str]:
+    query = tmp_path / "q.fa"
+    query.write_text(">q\nM\n")
+    return [
+        "run_blast",
+        "--query",
+        str(query),
+        "--out",
+        str(out),
+        "--max_target_seqs",
+        "10",
+        "--word_size",
+        "3",
+        "--word_size_backoff",
+        "2",
+        "--num_attempts",
+        "1",
+        "--evalue",
+        "0.05",
+    ]
+
+
+def test_run_blast_empty_tsv_hard_fails_by_default(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "blast.tsv"
+
+    def fake_run_blast(**kwargs):
+        pathlib.Path(kwargs["out"]).write_text("")
+        return blast_utils.BlastResult(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(run_blast.blast_utils, "run_blast", fake_run_blast)
+    monkeypatch.setattr(sys, "argv", _argv(tmp_path, out))
+    with pytest.raises(SystemExit) as exc:
+        run_blast.main()
+    assert exc.value.code != 0
+
+
+def test_run_blast_empty_tsv_soft_fail_exits_zero(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "blast.tsv"
+    monkeypatch.setenv("PC_BLAST_SOFT_FAIL", "1")
+
+    def fake_run_blast(**kwargs):
+        pathlib.Path(kwargs["out"]).write_text("")
+        return blast_utils.BlastResult(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(run_blast.blast_utils, "run_blast", fake_run_blast)
+    monkeypatch.setattr(sys, "argv", _argv(tmp_path, out))
+    with pytest.raises(SystemExit) as exc:
+        run_blast.main()
+    assert exc.value.code == 0

--- a/README.md
+++ b/README.md
@@ -193,9 +193,10 @@ The **Cluster** mode starts at the "Clustering" step.
     - The pipeline searches `afdb50`, `afdb-proteome` and `afdb-swissprot` for each input protein and aggregate the results. You can customize to add or remove databases using the config file.
     - Currently, the pipeline is limited to retrieving a maximum of 1000 hits per protein, per database.
 
-2. Search the non-redundant GenBank/RefSeq database using blastp for each provided `.fasta` file.
-    - Takes the resulting output hits and maps each GenBank/RefSeq hit to a UniProt ID using `requests` and [the UniProt REST API](https://rest.uniprot.org/docs/?urls.primaryName=idmapping#/job/submitJob).
-    - TODO: This can fail for large proteins (>700aa) due to remote BLAST CPU limits. To overcome this error, you can manually run BLAST locally or via the webserver and create an [accession list file](#accession-list-files-acc) with the name format `{protid}.blast_hits.refseq.txt` in the `output/blast_results/` directory.
+2. Search sequence databases using blastp for each provided `.fasta` file.
+    - By default the pipeline uses NCBI's WWW/QBlast API (`PC_BLAST_BACKEND=www`) against `refseq_protein`, which returns RefSeq accessions for UniProt ID mapping and avoids hung `blastp -remote` calls from cloud IPs. Set `PC_BLAST_DB=nr` and/or `PC_BLAST_BACKEND=remote` to restore the historical broader / CLI-remote behavior.
+    - Hits are mapped to UniProt IDs using `requests` and [the UniProt REST API](https://rest.uniprot.org/docs/?urls.primaryName=idmapping#/job/submitJob).
+    - If NCBI is unavailable, set `PC_BLAST_SOFT_FAIL=1` to continue with Foldseek-only hits (writes an empty BLAST results file after retries). You can also manually create an [accession list file](#accession-list-files-acc) with the name format `{protid}.blast_hits.refseq.txt` in the `output/blast_results/` directory.
 
 ### Download Data
 

--- a/envs/analysis.yml
+++ b/envs/analysis.yml
@@ -10,3 +10,9 @@ dependencies:
   - pandas=2.0.1
   - numpy=1.23.5
   - nltk=3.8.1
+  # matplotlib is an indirect dependency (via scanpy) and must be pinned. Recent versions are
+  # built against numpy 2 and raise `ImportError: Matplotlib requires numpy>=1.25` when they
+  # are imported alongside the numpy pinned above.
+  - matplotlib=3.7.1
+  # `umap-learn` imports `pkg_resources`, which setuptools removed in version 81.
+  - setuptools<81

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,8 @@ no-lines-before = ["future", "standard-library"]
 line_length = 100
 include = 'Snakefile|Snakefile_*'
 exclude = 'dev'
+
+[tool.pytest.ini_options]
+# Scripts live in ProteinCartography/ and import as top-level modules
+# (import blast_utils, not ProteinCartography.blast_utils).
+pythonpath = ["ProteinCartography"]


### PR DESCRIPTION
## Summary
- **BLAST:** default to NCBI WWW/QBlast (`PC_BLAST_BACKEND=www`, `PC_BLAST_DB=refseq_protein`) with timeout/heartbeat; keep `blastp -remote` via env. Optional `PC_BLAST_SOFT_FAIL=1` continues Foldseek-only when NCBI fails. Empty BLAST results no longer abort extract.
- **AlphaFold:** prefer `model_v6`, fall back to `v4` / prediction API; never write HTML/XML error bodies as PDBs (poisoned Foldseek → N≈1).
- **UniProt:** idmapping handles 303/ERROR, batches + retries; metadata uses `/uniprotkb/accessions` instead of 100-OR search.
- **Small N:** clamp UMAP/t-SNE/Leiden parameters; N<3 gets a degenerate layout / single cluster.
- Unit tests for BLAST XML→TSV and empty hit extraction. README BLAST TODO updated.

These fixes were developed while running ProteinCartography v0.5.0 search-mode on Modal for Arcadia Studio (`full` cartography). Upstream `main` already has AFDB v6 URL + Foldseek `F1-model` parse; this PR covers what still breaks real cloud/search runs.

## Test plan
- [x] `ruff check ProteinCartography` / `ruff format`
- [x] `pytest` unit tests: `test_blast_utils`, `test_extract_blast_hits`, `test_packaging`
- [ ] CI lint + mocked search/cluster pipeline (`make test`)
- [ ] Optional: add `run-slow-tests` label before merge for live API smoke

## Env knobs (optional)
| Var | Default | Purpose |
|-----|---------|---------|
| `PC_BLAST_BACKEND` | `www` | `www` / `remote` / `auto` |
| `PC_BLAST_DB` | `refseq_protein` (www) | set `nr` for broader historical search |
| `PC_BLAST_SOFT_FAIL` | `0` (run) / empty extract allowed | `1` to continue after BLAST failure |
| `PC_UNIPROT_MAP_*` / `PC_UNIPROT_META_*` | see scripts | batch/timeout/retry tuning |

Made with [Cursor](https://cursor.com)