### PR TITLE
Make `make lint` able to fail, and match the lint workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
+# These checks are the same ones that `.github/workflows/lint.yml` runs, in the same order,
+# so that a passing `make lint` means a passing lint workflow.
 .PHONY: lint
 lint:
-	ruff check --exit-zero .
+	ruff check .
+	ruff format --check .
 	snakefmt --check .
 
+# Note that `ruff check --fix` runs before `ruff format`, because the fixer's edits are not
+# themselves formatted; in the other order, a fix can leave the tree failing `make lint`.
 .PHONY: format
 format:
-	ruff format .
 	ruff check --fix .
+	ruff format .
 	snakefmt .
 
 .PHONY: pre-commit


### PR DESCRIPTION
`make lint` could not fail. `Makefile` line 3 was `ruff check --exit-zero .`, and `--exit-zero` forces an exit status of 0 regardless of findings, so a green `make lint` predicted nothing about CI. It also never ran `ruff format --check`, though `.github/workflows/lint.yml` does.

This makes the target run the same three checks as the workflow, in the same order.

## The two failure modes, demonstrated

Both were checked against the current tree with a deliberately broken file, using CI's pinned versions (ruff 0.1.6, snakefmt 0.8.5) under Python 3.9:

| broken file | before | after |
| --- | --- | --- |
| unused import (`F401`) | prints `Found 1 error.`, exits **0** | exits 1 |
| lint-clean but misformatted | **no output at all**, exits **0** | exits 1 |

The second row is the worse of the two. `--exit-zero` at least still printed the finding, so someone watching the scrollback could notice it. But with no `ruff format --check` at all, a file that CI rejects produced completely clean local output and a zero exit — there was nothing to notice.

## Also: the order of the two commands in `make format`

`make format` ran `ruff format` and then `ruff check --fix`. The fixer runs last, so its edits are never formatted afterwards. That is invisible while `make lint` ignores formatting, but this PR makes `make lint` enforce it, so it would become a fixed-point violation introduced by this change: run `make format`, then `make lint` fails.

It is reachable with an ordinary edit. Given this format-clean file:

```python
import os

import sys


def f():
    return sys.path
```

`ruff check --fix` removes the unused `os` and leaves the blank line that followed it, so the file starts with a blank line and `ruff format --check` then rejects it. Reversing the two commands produces a clean tree from the same input. This also matches ruff's own guidance to run the fixer before the formatter.

## Verification

- `make lint` exits 0 on the current tree.
- `make lint` exits non-zero for a lint error and for a formatting error (the table above); a fix that cannot be shown to fail is not verified.
- `make format` rewrites nothing on the current tree — the only modified file afterwards is the `Makefile` itself — and still fixes both broken files above.

## What was not verified

`make test` does not pass on this branch, and does not pass on unmodified `main` either. Two rules fail:

```
rule leiden_clustering:  ImportError: Matplotlib requires numpy>=1.25; you have 1.23.5
rule dim_reduction:      ModuleNotFoundError: No module named 'pkg_resources'
```

That is the `envs/analysis.yml` dependency drift fixed in #101, reproduced here independently on a clean checkout of current `main` with a fresh conda solve. It is unrelated to this PR, which touches only the `lint` and `format` targets in the `Makefile`. Worth noting as a second data point for #101: the drift is not specific to one machine or one day's package index.

`make smoke-test` was not run because that target does not exist on this base; it arrives with #101.

Stacking: #101 also edits the `Makefile`, adding a `smoke-test` target further down. The hunks are far apart and were checked to apply cleanly in either order.
