### PR TITLE
Declare tqdm in envs/web_apis.yml

### DIFF
--- a/envs/web_apis.yml
+++ b/envs/web_apis.yml
@@ -9,5 +9,8 @@ dependencies:
   - requests=2.29.0
   - biopython=1.81
   - ratelimiter=1.2.0
+  # `download_pdbs.py` imports tqdm directly. It is declared here rather than left to resolve as an
+  # indirect dependency of `bioservices`, which requires it without any version constraint.
+  - tqdm=4.65.0
   - pip:
       - bioservices==1.11.2


### PR DESCRIPTION
`ProteinCartography/download_pdbs.py:8` does `import tqdm`. The `download_pdbs` checkpoint runs under `envs/web_apis.yml` (`Snakefile:339`), which never declared it.

It resolves today only because the pip dependency `bioservices==1.11.2` requires it. Checked in the currently built environment:

```
tqdm version   : 4.70.0
installed via  : pip only          # no entry in conda-meta
bioservices declares: ['tqdm']     # no version constraint
```

So there are two problems, not one. The obvious one is that if `bioservices` ever drops `tqdm`, `download_pdbs` breaks with a `ModuleNotFoundError`. The less obvious one is that because the requirement is unconstrained, the *version* floats too — a fresh solve of this environment installs tqdm 4.70.0 today, while `cartography_dev.yml:33` and `cartography_pub.yml:14` both pin 4.65.0. This environment has been quietly drifting away from the rest of the repo.

This is the same class of latent breakage fixed in #101: a transitive dependency that resolves today and will not necessarily resolve tomorrow.

## Change

Add `tqdm=4.65.0` to `envs/web_apis.yml`, matching the two environments that already pin it.

## Verification

Solved the environment from scratch (osx-64) and confirmed the pin takes effect rather than being overridden by pip when it later installs `bioservices`:

```
tqdm version   : 4.65.0
installed via  : conda
import tqdm    : ok -> 4.65.0
import bioservices : ok -> 1.11.2
```

`tqdm` does not appear in pip's install list during the `bioservices` step, i.e. the conda-provided 4.65.0 satisfies the requirement and pip leaves it alone.

Then ran the affected script and its siblings under the rebuilt environment:

- `python ProteinCartography/download_pdbs.py --help` exits 0, which exercises the whole import chain (`api_utils`, `fetch_accession`, `tqdm`, `ratelimiter`).
- `fetch_accession`, `fetch_uniprot_metadata`, and `map_refseq_ids` — the other modules whose rules use this environment — all still import cleanly.

Note that this changes `hashFiles('envs/*.yml')` and so invalidates the CI conda cache key, forcing a fresh solve of the environments on this PR. That is the intended effect and is how the pin gets exercised in CI.

## What was not verified

`make smoke-test` was not run: that target does not exist on this base, it arrives with #101. `make test` does not pass on this base either, but for an unrelated reason — the `envs/analysis.yml` drift fixed in #101 (`ImportError: Matplotlib requires numpy>=1.25` in `leiden_clustering`, `ModuleNotFoundError: No module named 'pkg_resources'` in `dim_reduction`). Neither failure involves `web_apis.yml`.

## Considered and deliberately not included

`bioservices/__init__.py` also does a module-scope `import pkg_resources`, which setuptools removes in version 81 — the same hazard #101 pins against in `envs/analysis.yml`. A `setuptools<81` pin is **not** needed here: this environment pins `python=3.9.16`, and setuptools 81 requires `python>=3.10`, so conda cannot resolve a setuptools that would break it (`setuptools[version='>=81'] -> python[version='>=3.10']`). `analysis.yml` needed the pin because it runs Python 3.11.
