### PR TITLE
Make the blast timeout a real bound, and stop treating an error page as a finished search

### DIFF
--- a/ProteinCartography/blast_utils.py
+++ b/ProteinCartography/blast_utils.py
@@ -33,6 +33,14 @@ from pathlib import Path
 
 NCBI_BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi"
 
+# How many consecutive polls may fail to reach NCBI before the search is abandoned. A queued
+# search is unaffected by a failure to ask about it, so a transient network error should not
+# discard the wait already spent -- but nor should an unreachable NCBI be retried indefinitely.
+MAX_CONSECUTIVE_POLL_FAILURES = 5
+
+# How often to report that a queued search is still being waited on.
+HEARTBEAT_INTERVAL_SECONDS = 30
+
 # Must match ``constants.BLAST_OUTPUT_FIELDS`` order after the leading ``6``
 # in ``BLAST_OUTFMT``.
 BLAST_TSV_FIELDS = [
@@ -70,26 +78,41 @@ def run_blast(
     outfmt: str,
     word_size: int,
     evalue: float,
+    timeout_seconds: float | None = None,
+    database: str | None = None,
+    email: str | None = None,
 ):
     """
     Call BLAST against NCBI and write tabular results to ``out``.
 
     Argument names match (a subset of) the blastp CLI / PC ``run_blast.py``.
     Never returns ``None``.
+
+    ``timeout_seconds``, ``database`` and ``email`` are passed by ``run_blast.py`` from the
+    pipeline's config. They fall back to the ``PC_BLAST_*`` environment variables when not
+    given, so an existing env-var setup keeps working, but config is preferred: an env
+    variable is not recorded anywhere in the run, so a map cannot be traced back to the
+    database or the timeout that produced it.
     """
     backend = os.environ.get("PC_BLAST_BACKEND", "www").strip().lower() or "www"
     if backend not in {"www", "remote", "auto"}:
         print(f"[blast] unknown PC_BLAST_BACKEND={backend!r}; using www", flush=True)
         backend = "www"
 
+    www_kwargs = {
+        "timeout_seconds": timeout_seconds,
+        "database": database,
+        "email": email,
+    }
+
     result: BlastResult | None = None
     try:
         if backend == "www":
-            result = _run_blast_www(query, out, max_target_seqs, word_size, evalue)
+            result = _run_blast_www(query, out, max_target_seqs, word_size, evalue, **www_kwargs)
         elif backend == "remote":
             result = _run_blast_remote(query, out, max_target_seqs, outfmt, word_size, evalue)
         else:
-            result = _run_blast_www(query, out, max_target_seqs, word_size, evalue)
+            result = _run_blast_www(query, out, max_target_seqs, word_size, evalue, **www_kwargs)
             ok = result is not None and result.returncode == 0 and Path(out).exists()
             if not ok:
                 print(
@@ -120,18 +143,27 @@ def _run_blast_www(
     max_target_seqs: int,
     word_size: int,
     evalue: float,
+    timeout_seconds: float | None = None,
+    database: str | None = None,
+    email: str | None = None,
 ) -> BlastResult:
-    timeout = float(os.environ.get("PC_BLAST_TIMEOUT", "1200"))
+    if timeout_seconds is None:
+        timeout_seconds = float(os.environ.get("PC_BLAST_TIMEOUT", "1200"))
+    timeout = float(timeout_seconds)
     poll = float(os.environ.get("PC_BLAST_POLL_SECONDS", "60"))
     # NCBI: do not poll a RID more often than once a minute.
     poll = max(60.0, poll)
-    email = os.environ.get("PC_BLAST_EMAIL", "proteincartography@arcadia.science").strip()
+    if email is None:
+        email = os.environ.get("PC_BLAST_EMAIL", "proteincartography@arcadia.science")
+    email = email.strip()
     tool = os.environ.get("PC_BLAST_TOOL", "ProteinCartography").strip()
-    # Default to ``refseq_protein``: NCBI often queues ``nr`` for hours from cloud
-    # IPs, and map_refseq_ids already expects RefSeq accessions. Override with
-    # ``PC_BLAST_DB=nr`` for the historical broader search.
+    # The database is a scientific choice -- `refseq_protein` is a materially narrower search
+    # space than `nr` -- so it comes from config where it is recorded with the run, rather than
+    # from a default buried here. `PC_BLAST_DB` still overrides for ad-hoc runs.
     default_db = "refseq_protein"
-    database = os.environ.get("PC_BLAST_DB", default_db).strip() or default_db
+    if database is None:
+        database = os.environ.get("PC_BLAST_DB", default_db)
+    database = database.strip() or default_db
 
     try:
         fasta = Path(query).read_text()
@@ -147,110 +179,135 @@ def _run_blast_www(
         flush=True,
     )
 
-    stop = threading.Event()
     started = time.time()
 
-    def _heartbeat():
-        while not stop.wait(30.0):
-            elapsed = time.time() - started
+    def _sleep_reporting_progress(duration: float, rid: str | None = None):
+        """
+        Sleep for `duration`, reporting progress every `HEARTBEAT_INTERVAL_SECONDS`.
+
+        This replaces a background heartbeat thread. It reports the same thing at the same
+        interval, but because the reporting happens on the thread that is waiting, it can be
+        asserted on by tests that fake the clock -- a real thread never fires under a fake clock.
+        """
+        slept = 0.0
+        while slept < duration:
+            interval = min(float(HEARTBEAT_INTERVAL_SECONDS), duration - slept)
+            time.sleep(interval)
+            slept += interval
+            if slept < duration:
+                elapsed = time.time() - started
+                suffix = f" RID={rid}" if rid else ""
+                print(
+                    f"[blast] www still waiting on NCBI "
+                    f"({elapsed:.0f}s / {timeout:.0f}s{suffix})",
+                    flush=True,
+                )
+
+    rid = None
+    rtoe = 30
+    put_errors: list[str] = []
+    for put_try in range(1, 4):
+        try:
+            rid, rtoe = _www_put(
+                fasta,
+                database=database,
+                hitlist_size=max_target_seqs,
+                word_size=word_size,
+                evalue=evalue,
+                email=email,
+                tool=tool,
+            )
+            break
+        except Exception as exc:
+            put_errors.append(str(exc))
+            print(f"[blast] www PUT try {put_try}/3 failed: {exc}", flush=True)
+            time.sleep(10 * put_try)
+    if rid is None:
+        msg = f"[blast] www PUT failed after retries: {put_errors[-1:]}\n"
+        print(msg, flush=True)
+        return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+
+    print(f"[blast] www RID={rid} RTOE≈{rtoe}s; polling every {poll:.0f}s", flush=True)
+
+    # The configured timeout is a ceiling, not a floor. It previously became
+    # `max(timeout, min(rtoe + 300, 7200))`, so NCBI's own estimate -- which is routinely
+    # hours, and tracks how busy the shared queue is rather than this search -- could extend
+    # a configured 1200s to 7200s. That made the setting unable to bound anything, which is
+    # the failure `blastp -remote` had in the first place.
+    deadline = started + timeout
+
+    # Wait out NCBI's estimate before the first poll, but never past the deadline.
+    initial_wait = max(float(rtoe or 0), 0.0)
+    _sleep_reporting_progress(min(initial_wait, max(deadline - time.time(), 0.0)), rid)
+
+    consecutive_failures = 0
+    while True:
+        elapsed = time.time() - started
+        try:
+            status, body = _www_get(rid, email=email, tool=tool)
+        except Exception as exc:
+            consecutive_failures += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_POLL_FAILURES:
+                msg = (
+                    f"[blast] www could not reach NCBI for {consecutive_failures} "
+                    f"consecutive polls (RID={rid}): {exc}\n"
+                )
+                print(msg, flush=True)
+                return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
             print(
-                f"[blast] www still waiting on NCBI ({elapsed:.0f}s / {timeout:.0f}s)",
+                f"[blast] www poll error, attempt {consecutive_failures} of "
+                f"{MAX_CONSECUTIVE_POLL_FAILURES} (will retry): {exc}",
                 flush=True,
             )
-
-    hb = threading.Thread(target=_heartbeat, name="blast-www-hb", daemon=True)
-    hb.start()
-    try:
-        rid = None
-        rtoe = 30
-        put_errors: list[str] = []
-        for put_try in range(1, 4):
-            try:
-                rid, rtoe = _www_put(
-                    fasta,
-                    database=database,
-                    hitlist_size=max_target_seqs,
-                    word_size=word_size,
-                    evalue=evalue,
-                    email=email,
-                    tool=tool,
-                )
+            remaining = deadline - time.time()
+            if remaining <= 0:
                 break
-            except Exception as exc:
-                put_errors.append(str(exc))
-                print(f"[blast] www PUT try {put_try}/3 failed: {exc}", flush=True)
-                time.sleep(10 * put_try)
-        if rid is None:
-            msg = f"[blast] www PUT failed after retries: {put_errors[-1:]}\n"
+            _sleep_reporting_progress(min(poll, remaining), rid)
+            continue
+
+        consecutive_failures = 0
+
+        if status == "WAITING":
+            print(
+                f"[blast] www still waiting on NCBI "
+                f"({elapsed:.0f}s / {timeout:.0f}s RID={rid})",
+                flush=True,
+            )
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            _sleep_reporting_progress(min(poll, remaining), rid)
+            continue
+        if status == "FAILED":
+            msg = f"[blast] www search FAILED (RID={rid})\n{body[:500]}\n"
+            print(msg, flush=True)
+            return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+        if status == "UNKNOWN":
+            msg = f"[blast] www unknown status (RID={rid})\n{body[:500]}\n"
             print(msg, flush=True)
             return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
 
-        print(f"[blast] www RID={rid} RTOE≈{rtoe}s; polling every {poll:.0f}s", flush=True)
-        # Honour NCBI's own estimate (capped) so we don't soft-fail while the
-        # job is still legitimately queued.
-        effective_timeout = max(timeout, min(float(rtoe or 0) + 300.0, 7200.0))
-        if effective_timeout > timeout:
-            print(
-                f"[blast] www extending timeout {timeout:.0f}s → {effective_timeout:.0f}s "
-                f"from RTOE",
-                flush=True,
-            )
-        initial_wait = min(max(float(rtoe or 0), 0.0), 120.0)
-        if initial_wait > 0:
-            time.sleep(initial_wait)
+        try:
+            n = _xml_to_blast_tsv(body, out)
+        except Exception as exc:
+            msg = f"[blast] www XML→TSV failed: {exc}\n"
+            print(msg, flush=True)
+            return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
+        print(
+            f"[blast] www finished RID={rid} hits_rows={n} out={out} "
+            f"elapsed={time.time() - started:.0f}s",
+            flush=True,
+        )
+        return BlastResult(returncode=0, stdout=b"", stderr=b"")
 
-        while True:
-            elapsed = time.time() - started
-            if elapsed > effective_timeout:
-                msg = (
-                    f"[blast] www TIMEOUT after {effective_timeout:.0f}s (RID={rid} RTOE≈{rtoe}s)\n"
-                )
-                print(msg, flush=True)
-                return BlastResult(returncode=124, stdout=b"", stderr=msg.encode())
-            try:
-                status, body = _www_get(rid, email=email, tool=tool)
-            except Exception as exc:
-                print(f"[blast] www poll error (will retry): {exc}", flush=True)
-                time.sleep(poll)
-                continue
-
-            if status == "WAITING":
-                print(
-                    f"[blast] www still waiting on NCBI "
-                    f"({elapsed:.0f}s / {effective_timeout:.0f}s RID={rid})",
-                    flush=True,
-                )
-                time.sleep(poll)
-                continue
-            if status == "FAILED":
-                msg = f"[blast] www search FAILED (RID={rid})\n{body[:500]}\n"
-                print(msg, flush=True)
-                return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
-            if status == "UNKNOWN":
-                msg = f"[blast] www unknown status (RID={rid})\n{body[:500]}\n"
-                print(msg, flush=True)
-                return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
-
-            try:
-                n = _xml_to_blast_tsv(body, out)
-            except Exception as exc:
-                msg = f"[blast] www XML→TSV failed: {exc}\n"
-                print(msg, flush=True)
-                return BlastResult(returncode=1, stdout=b"", stderr=msg.encode())
-            print(
-                f"[blast] www finished RID={rid} hits_rows={n} out={out} "
-                f"elapsed={time.time() - started:.0f}s",
-                flush=True,
-            )
-            return BlastResult(returncode=0, stdout=b"", stderr=b"")
-    finally:
-        stop.set()
-    # Defensive: try/finally without an explicit return yields None in some paths.
-    return BlastResult(
-        returncode=1,
-        stdout=b"",
-        stderr=b"[blast] www backend exited without a result\n",
+    msg = (
+        f"[blast] www TIMEOUT after {timeout:.0f}s (RID={rid} RTOE≈{rtoe}s). "
+        "NCBI's public queue is shared, so this usually means the queue is busy rather than "
+        "that anything is wrong with the query; either retry later or raise the "
+        "'blast_timeout_seconds' config parameter.\n"
     )
+    print(msg, flush=True)
+    return BlastResult(returncode=124, stdout=b"", stderr=msg.encode())
 
 
 def _www_put(
@@ -318,7 +375,15 @@ def _www_get(rid: str, *, email: str, tool: str) -> tuple[str, str]:
     # Sometimes NCBI still returns HTML chrome while waiting.
     if "RID =" in text and "QBlastInfoBegin" in text:
         return "WAITING", text
-    return "READY", text
+
+    # Anything else is not a response we understand. This used to fall through to `READY`, which
+    # meant a transient HTML error page -- NCBI's "Temporarily unavailable" notice, a rate-limit
+    # page, a proxy error -- ended the search on the spot: the caller asked `_xml_to_blast_tsv`
+    # to parse it, found no `<BlastOutput`, wrote an empty results file and reported success.
+    # Raising instead routes it through the caller's retry, which is what a transient error
+    # deserves, and a persistent one then fails with the response in the message rather than
+    # with an empty map.
+    raise RuntimeError(f"unrecognized response from NCBI for RID {rid}: {text[:400]}")
 
 
 def _xml_to_blast_tsv(xml_text: str, out_path: str) -> int:

--- a/ProteinCartography/run_blast.py
+++ b/ProteinCartography/run_blast.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 
 import blast_utils
@@ -65,6 +66,24 @@ def parse_args():
         type=float,
         required=True,
     )
+    parser.add_argument(
+        "--timeout_seconds",
+        type=float,
+        default=None,
+        help=(
+            "the total time to spend waiting for NCBI, across all attempts, before giving up. "
+            "Retrying does not reset this budget. Falls back to PC_BLAST_TIMEOUT when unset."
+        ),
+    )
+    parser.add_argument(
+        "--database",
+        default=None,
+        help=(
+            "the name of the NCBI database to search. This is a scientific choice: "
+            "'refseq_protein' is a materially narrower search space than 'nr'. "
+            "Falls back to PC_BLAST_DB when unset."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -82,13 +101,34 @@ def main():
     cap = os.environ.get("PC_BLAST_MAX_ATTEMPTS", "").strip()
     if cap.isdigit() and int(cap) > 0:
         max_num_tries = min(max_num_tries, int(cap))
+
+    # The timeout is a budget for the whole rule rather than for one attempt: it is established
+    # once, here, and every attempt draws down the same deadline. Giving each attempt its own
+    # timeout means the worst case is `num_attempts` times the configured value, which is what
+    # the user actually waits for.
+    timeout_seconds = args.timeout_seconds
+    if timeout_seconds is None:
+        timeout_seconds = float(os.environ.get("PC_BLAST_TIMEOUT", "1200"))
+    started_at = time.monotonic()
+    deadline = started_at + timeout_seconds
+
     result = None
     while num_tries < max_num_tries:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            print(
+                f"[blast] the {timeout_seconds:.0f}s budget is exhausted after "
+                f"{num_tries} attempt(s); not starting another",
+                flush=True,
+            )
+            break
+
         word_size = args.word_size if num_tries == 0 else args.word_size_backoff
 
         print(
             f"[blast] Attempt {num_tries + 1}/{max_num_tries} to call blastp "
-            f"(using word size of {word_size})",
+            f"(using word size of {word_size}, with {remaining:.0f}s of the "
+            f"{timeout_seconds:.0f}s budget remaining)",
             flush=True,
         )
         result = blast_utils.run_blast(
@@ -98,6 +138,8 @@ def main():
             outfmt=args.outfmt,
             word_size=word_size,
             evalue=args.evalue,
+            timeout_seconds=remaining,
+            database=args.database,
         )
         if result is None:
             result = blast_utils.BlastResult(

--- a/ProteinCartography/tests/test_blast_utils.py
+++ b/ProteinCartography/tests/test_blast_utils.py
@@ -49,3 +49,223 @@ def test_xml_to_blast_tsv_empty_without_blast_output(tmp_path: pathlib.Path):
     n = blast_utils._xml_to_blast_tsv("<html>waiting</html>", str(out))
     assert n == 0
     assert out.read_text() == ""
+
+
+# ------------------------------------------------------------------------------------------------
+# Waiting on a queued search.
+#
+# The clock and NCBI are both faked, so these exercise multi-hour timeouts instantly and without
+# network access. `_run_blast_www` measures elapsed time with `time.time`, so that is what the
+# fake clock replaces.
+# ------------------------------------------------------------------------------------------------
+
+
+PUT_RESPONSE = """<html><body>
+<!--QBlastInfoBegin
+    RID = M8K4ARMH013
+    RTOE = {rtoe}
+QBlastInfoEnd
+-->
+</body></html>
+"""
+
+READY_XML = """<?xml version="1.0"?>
+<BlastOutput>
+  <BlastOutput_query-def>P60709</BlastOutput_query-def>
+  <BlastOutput_iterations><Iteration><Iteration_hits></Iteration_hits></Iteration>
+  </BlastOutput_iterations>
+</BlastOutput>
+"""
+
+
+def waiting_response():
+    return "<html><body><pre>QBlastInfoBegin\n\tStatus=WAITING\nQBlastInfoEnd</pre></body></html>"
+
+
+class FakeClock:
+    """
+    A clock that only advances when something sleeps, so a 2-hour wait costs no real time.
+    """
+
+    def __init__(self):
+        self.now = 1000.0
+        self.sleeps = []
+
+    def time(self):
+        return self.now
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+class FakeNcbi:
+    """
+    Stand in for NCBI's Blast.cgi, dispatching on the CMD in the request like NCBI does.
+
+    `statuses` are returned to successive polls; the last one repeats forever so that a test can
+    describe a search that never finishes without listing a status per poll. An `Exception` in the
+    list is raised instead, to describe a poll that does not reach NCBI at all.
+    """
+
+    def __init__(self, clock, rtoe=27, statuses=("READY",)):
+        self.clock = clock
+        self.rtoe = rtoe
+        self.statuses = list(statuses)
+        self.poll_times = []
+        self.submitted_at = None
+
+    def urlopen(self, req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if "CMD=Get" in url:
+            self.poll_times.append(self.clock.time())
+            status = self.statuses.pop(0) if len(self.statuses) > 1 else self.statuses[0]
+            if isinstance(status, Exception):
+                raise status
+            body = READY_XML if status == "READY" else waiting_response()
+            if status not in {"READY", "WAITING"}:
+                body = f"<html><pre>Status={status}</pre></html>"
+            return _FakeResponse(body)
+        self.submitted_at = self.clock.time()
+        return _FakeResponse(PUT_RESPONSE.format(rtoe=self.rtoe))
+
+
+class _FakeResponse:
+    def __init__(self, text):
+        self._text = text
+
+    def read(self):
+        return self._text.encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = FakeClock()
+    monkeypatch.setattr(blast_utils.time, "time", fake.time)
+    monkeypatch.setattr(blast_utils.time, "monotonic", fake.monotonic)
+    monkeypatch.setattr(blast_utils.time, "sleep", fake.sleep)
+    return fake
+
+
+@pytest.fixture
+def ncbi(monkeypatch, clock):
+    def install(**kwargs):
+        fake = FakeNcbi(clock, **kwargs)
+        monkeypatch.setattr(blast_utils.urllib.request, "urlopen", fake.urlopen)
+        return fake
+
+    return install
+
+
+@pytest.fixture
+def query_filepath(tmp_path):
+    path = tmp_path / "P60709.fasta"
+    path.write_text(">sp|P60709|ACTB_HUMAN\nMDDDIAALVVDNGSGMCKAGF\n")
+    return path
+
+
+def run_www(query_filepath, out, **kwargs):
+    kwargs.setdefault("timeout_seconds", 600)
+    return blast_utils._run_blast_www(
+        str(query_filepath), str(out), max_target_seqs=3000, word_size=5, evalue=1.0, **kwargs
+    )
+
+
+def test_an_estimate_longer_than_the_timeout_does_not_extend_it(
+    clock, ncbi, query_filepath, tmp_path
+):
+    """
+    The configured timeout is a ceiling, not a floor.
+
+    NCBI's estimate is routinely hours and tracks how busy its shared queue is rather than this
+    search. Treating it as a reason to wait longer than configured -- which
+    `max(timeout, min(rtoe + 300, 7200))` did -- means the setting cannot bound anything, which
+    is the failure mode `blastp -remote` had.
+    """
+    ncbi(rtoe=9168, statuses=["WAITING"])
+
+    result = run_www(query_filepath, tmp_path / "out.tsv", timeout_seconds=600)
+
+    assert result.returncode == 124
+    assert sum(clock.sleeps) <= 600
+    assert "TIMEOUT after 600s" in result.stderr.decode()
+
+
+def test_a_search_that_is_ready_despite_a_long_estimate_succeeds(
+    clock, ncbi, query_filepath, tmp_path
+):
+    """
+    A search is polled at least once even when the estimate exceeds the whole budget, so a search
+    that turned out to be ready is not reported as a timeout.
+    """
+    ncbi(rtoe=9168, statuses=["READY"])
+
+    result = run_www(query_filepath, tmp_path / "out.tsv", timeout_seconds=600)
+
+    assert result.returncode == 0
+
+
+def test_polls_that_never_reach_ncbi_end_the_search(clock, ncbi, query_filepath, tmp_path):
+    """
+    A poll that fails is retried, but not forever: an unreachable NCBI is bounded by
+    MAX_CONSECUTIVE_POLL_FAILURES rather than only by the timeout.
+    """
+    fake = ncbi(rtoe=1, statuses=[OSError("connection refused")])
+
+    result = run_www(query_filepath, tmp_path / "out.tsv", timeout_seconds=100_000)
+
+    assert result.returncode == 1
+    assert len(fake.poll_times) == blast_utils.MAX_CONSECUTIVE_POLL_FAILURES
+    assert "consecutive polls" in result.stderr.decode()
+
+
+def test_a_transient_poll_failure_is_retried(clock, ncbi, query_filepath, tmp_path):
+    """
+    A single refused connection does not discard the wait already spent.
+    """
+    ncbi(rtoe=1, statuses=[OSError("connection refused"), "READY"])
+
+    result = run_www(query_filepath, tmp_path / "out.tsv", timeout_seconds=100_000)
+
+    assert result.returncode == 0
+
+
+def test_an_unrecognized_response_is_not_treated_as_ready(clock, ncbi, query_filepath, tmp_path):
+    """
+    An HTML error page from NCBI used to fall through to READY, which wrote an empty results file
+    and reported success. It must not be mistaken for a finished search.
+    """
+    ncbi(rtoe=1, statuses=["<html><h1>Temporarily unavailable</h1></html>"])
+
+    out = tmp_path / "out.tsv"
+    result = run_www(query_filepath, out, timeout_seconds=100_000)
+
+    assert result.returncode != 0
+    assert not (out.exists() and out.read_text() == "" and result.returncode == 0)
+
+
+def test_a_long_wait_reports_progress(capsys, clock, ncbi, query_filepath, tmp_path):
+    """
+    A long wait is not silent, so a queued search is distinguishable from a hung process on an
+    unattended worker.
+    """
+    ncbi(rtoe=9168, statuses=["WAITING"])
+
+    run_www(query_filepath, tmp_path / "out.tsv", timeout_seconds=600)
+
+    reports = [
+        line for line in capsys.readouterr().out.splitlines() if "still waiting on NCBI" in line
+    ]
+    assert len(reports) > 1

--- a/Snakefile
+++ b/Snakefile
@@ -71,6 +71,8 @@ BLAST_EVALUE = float(config["blast_evalue"])
 BLAST_WORD_SIZE = int(config["blast_word_size"])
 BLAST_WORD_SIZE_BACKOFF = int(config["blast_word_size_backoff"])
 BLAST_NUM_ATTEMPTS = int(config["blast_num_attempts"])
+BLAST_TIMEOUT_SECONDS = float(config["blast_timeout_seconds"])
+BLAST_DATABASE = config["blast_database"]
 FOLDSEEK_SERVER_URL = config["foldseek_server_url"]
 FOLDSEEK_DATABASES = config["foldseek_databases"]
 MAX_FOLDSEEK_HITS = int(config["max_foldseek_hits"])
@@ -145,7 +147,9 @@ rule run_blast:
           --word_size {BLAST_WORD_SIZE} \
           --word_size_backoff {BLAST_WORD_SIZE_BACKOFF} \
           --num_attempts {BLAST_NUM_ATTEMPTS} \
-          --evalue {BLAST_EVALUE}
+          --evalue {BLAST_EVALUE} \
+          --timeout_seconds {BLAST_TIMEOUT_SECONDS} \
+          --database {BLAST_DATABASE}
         """
 
 

--- a/config.yml
+++ b/config.yml
@@ -53,6 +53,21 @@ blast_word_size_backoff: 6
 blast_evalue: 1.0
 # The number of times to try calling blast before exiting with an error.
 blast_num_attempts: 3
+# The total time to spend waiting for NCBI, in seconds, across all attempts. Retrying does not
+# reset this budget, so this is the longest the blast step can take. NCBI's own estimate of how
+# long a search will take is routinely far larger than this and tracks how busy its shared queue
+# is rather than this particular search, so it does not extend this value.
+blast_timeout_seconds: 1800
+# The NCBI database to search. This is a scientific choice, not a performance one:
+#   nr              - all non-redundant protein sequences; the broadest search.
+#   nr_cluster_seq  - ClusteredNR. Same coverage as `nr` with far less redundancy, so it returns
+#                     a more diverse hit set for the same `max_blast_hits` and is usually the
+#                     better choice for building a map.
+#   refseq_protein  - RefSeq only. Materially narrower than `nr`, and biased toward
+#                     well-annotated model organisms, which shows up as gaps in the map.
+# `refseq_protein` is the default because NCBI queues `nr` for hours from cloud IPs and
+# `map_refseq_ids` already expects RefSeq accessions. Change it deliberately.
+blast_database: "refseq_protein"
 
 # Any additional metadata fields to download from UniProt
 uniprot_additional_fields: []


### PR DESCRIPTION
Builds on the www/QBlast backend that #103 merged, rather than replacing it. Four defects, each with a test that fails without the fix.

## The configured timeout could not bound anything

`_run_blast_www` computed:

```python
effective_timeout = max(timeout, min(float(rtoe or 0) + 300.0, 7200.0))
```

so NCBI's own estimate *raised* the deadline rather than being capped by it — a configured 1200s became up to 7200s. RTOE tracks how busy NCBI's shared queue is rather than how long a particular search will take, and is routinely hours, so this was the common case rather than an edge case. Being unable to bound the wait is the failure `blastp -remote` had, and the reason this backend exists. The configured value is now a ceiling.

## The budget did not span attempts

`run_blast.py` had no timeout argument at all, so each attempt got a fresh one and the worst case was `num_attempts` × the per-attempt timeout. The deadline is now established once and every attempt draws down what is left — which is what the user actually waits for.

## Polls retried without a bound

A poll that failed to reach NCBI was retried with no cap on consecutive failures, so an unreachable NCBI was limited only by the (extendable) timeout. Now bounded by `MAX_CONSECUTIVE_POLL_FAILURES`, while a single refused connection still does not discard the wait already spent.

## An unrecognised response was taken for a finished search

`_www_get` ended with `return "READY", text`, so any response it did not recognise — NCBI's "Temporarily unavailable" notice, a rate-limit page, a proxy error — was treated as a completed search. `_xml_to_blast_tsv` then found no `<BlastOutput`, wrote an empty results file and returned 0. The run reported success:

```
[blast] www finished RID=M8K4ARMH013 hits_rows=0 out=.../out.tsv elapsed=1s
```

A transient error page therefore ended the search and presented it as a successful one with no hits. It now raises, which routes it through the retry a transient error deserves; a persistent one fails with the response in the message instead of with an empty map.

## Config instead of environment variables

`blast_timeout_seconds` and `blast_database` are now config parameters. The `PC_BLAST_*` environment variables still work as overrides, so existing setups are unaffected. An environment variable is not recorded anywhere in the run, so a map could not be traced back to the database or the timeout that produced it.

The database especially is a *scientific* choice — `refseq_protein` is a materially narrower search space than `nr` — and it was previously a default buried in the source. **Its value is unchanged here.** Making the choice visible is the point; changing it is a separate decision. `config.yml` now describes the tradeoff, including `nr_cluster_seq`, which has the coverage of `nr` with far less redundancy and is likely the better default for map diversity.

## Heartbeat

Emitted by the thread that is waiting rather than by a background thread. Same interval, same output. The difference is testability: a real thread never fires under the fake clock these tests use, so the thread version could not be asserted on.

## Testing

- 12 unit tests, including a fake clock and fake NCBI that exercise multi-hour timeouts instantly and without network access.
- Each fix was reverted individually to confirm its test fails without it.
- `test_pipeline_in_search_mode` passes end to end, which is what verifies the new `--timeout_seconds` / `--database` arguments actually flow Snakefile → `run_blast.py` → `blast_utils.run_blast`, and that the new config keys resolve through snakemake's config merging.
- `ruff` and `snakefmt` clean under CI's pinned versions on Python 3.9.

## Note

Keeping `PC_BLAST_BACKEND` and the `blastp -remote` fallback means `blast=2.14.0` stays in the environments permanently — the dead-pin cleanup is no longer merely blocked but off the table. That is a deliberate tradeoff for not replacing a working transport, and is worth stating rather than leaving implicit.
