### PR TITLE
Fix the CI conda cache, the Snakefile f-strings, and blastp calls that fail but exit zero

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,11 @@ jobs:
         with:
           path: .snakemake/conda
           key: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('envs/*.yml') }}
-          restore-keys: snakemake-conda-${{ runner.os }}--${{ runner.arch }}--
+          # note: there are deliberately no `restore-keys` here. A `restore-keys` match still
+          # leaves `cache-hit` false, so the step below runs anyway and begins by deleting
+          # `.snakemake/conda` -- meaning a partial match would download a stale multi-gigabyte
+          # cache only to discard it. (The `restore-keys` this replaces began with
+          # "snakemake-conda-" while the key begins with "conda-", so it never matched at all.)
 
       - name: Create the snakemake conda envs
         if: steps.cache-snakemake-conda-envs.outputs.cache-hit != 'true'

--- a/ProteinCartography/blast_utils.py
+++ b/ProteinCartography/blast_utils.py
@@ -33,6 +33,40 @@ from pathlib import Path
 
 NCBI_BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi"
 
+
+def blast_call_failed(result) -> bool:
+    """
+    Determine whether a call to the `blastp` CLI failed.
+
+    The exit code alone is not sufficient: when the remote server refuses to queue a request,
+    `blastp -remote` writes an error to stderr, writes an empty results file, and nevertheless
+    exits with a status of zero. For example:
+
+        Error: [blastp] bad_request: Could not queue request: DB operation failed.
+
+    Checking only the exit code therefore treats these failures as successes, which prevents the
+    word-size backoff in `run_blast.py` from ever being attempted and defers the failure to
+    `extract_blast_hits.py`, where it surfaces as a misleading "no hits were returned".
+
+    Note: an empty results file is deliberately *not* treated as a failure here, because a query
+    that legitimately has no hits also produces one.
+
+    Args:
+        result: the result of the call, with `returncode` and `stderr` attributes.
+
+    Returns:
+        True if the call failed.
+    """
+    if result.returncode != 0:
+        return True
+
+    stderr = result.stderr
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+
+    return "Error:" in (stderr or "")
+
+
 # Must match ``constants.BLAST_OUTPUT_FIELDS`` order after the leading ``6``
 # in ``BLAST_OUTFMT``.
 BLAST_TSV_FIELDS = [
@@ -504,4 +538,12 @@ def _run_blast_remote(
         if err_tail.strip():
             print(f"[blast] blastp stderr (tail):\n{err_tail}", flush=True)
     print(f"[blast] blastp finished rc={result.returncode}", flush=True)
+
+    # A refused request exits zero with the error only on stderr, so the exit code is reported
+    # back as a non-failure and the caller's word-size backoff never runs. Surface it as the
+    # failure it is, keeping the original stderr for the caller's error message.
+    if blast_call_failed(result) and result.returncode == 0:
+        print("[blast] blastp reported an error despite exiting zero; treating as a failure")
+        return BlastResult(returncode=1, stdout=result.stdout, stderr=result.stderr)
+
     return result

--- a/ProteinCartography/tests/test_blast_utils.py
+++ b/ProteinCartography/tests/test_blast_utils.py
@@ -49,3 +49,48 @@ def test_xml_to_blast_tsv_empty_without_blast_output(tmp_path: pathlib.Path):
     n = blast_utils._xml_to_blast_tsv("<html>waiting</html>", str(out))
     assert n == 0
     assert out.read_text() == ""
+
+
+# ------------------------------------------------------------------------------------------------
+# Detecting a `blastp -remote` call that failed but exited zero.
+# ------------------------------------------------------------------------------------------------
+
+
+class _Completed:
+    def __init__(self, returncode=0, stderr=b""):
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = b""
+
+
+def test_a_successful_call_did_not_fail():
+    assert not blast_utils.blast_call_failed(_Completed())
+
+
+def test_a_nonzero_exit_code_is_a_failure():
+    assert blast_utils.blast_call_failed(_Completed(returncode=1))
+
+
+def test_an_error_on_stderr_is_a_failure_despite_a_zero_exit_code():
+    """
+    The case this exists for: when the remote server refuses to queue the request, `blastp
+    -remote` reports the error, writes an empty results file, and still exits zero. Branching on
+    the exit code alone treats that as a success, so the word-size backoff never runs and the
+    failure surfaces later as a misleading "no hits were returned".
+    """
+    stderr = (
+        b"Error: [blastp] bad_request: Could not queue request: DB operation failed."
+        b"(ERR:-99  )((Severe Error) DB Put Request error: sp_NewRequestEx failed)\n"
+    )
+    assert blast_utils.blast_call_failed(_Completed(returncode=0, stderr=stderr))
+
+
+def test_a_warning_on_stderr_is_not_a_failure():
+    stderr = b"Warning: [blastp] Examining 5 or more matches is recommended\n"
+    assert not blast_utils.blast_call_failed(_Completed(returncode=0, stderr=stderr))
+
+
+def test_stderr_may_be_bytes_a_string_or_none():
+    assert blast_utils.blast_call_failed(_Completed(stderr="Error: something went wrong"))
+    assert not blast_utils.blast_call_failed(_Completed(stderr="all good"))
+    assert not blast_utils.blast_call_failed(_Completed(stderr=None))

--- a/Snakefile
+++ b/Snakefile
@@ -636,7 +636,7 @@ rule plot_interactive:
         tm_scores=rules.dim_reduction.output.all_by_all_tmscores,
         features=rules.aggregate_features.output.aggregated_features,
     output:
-        html=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_aggregated_features_{{plotting_mode}}.html",
+        html=FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_aggregated_features_{plotting_mode}.html"),
     conda:
         "envs/plotting.yml"
     benchmark:
@@ -752,7 +752,7 @@ rule plot_cluster_distributions:
     input:
         features=rules.aggregate_features.output.aggregated_features,
     output:
-        svg=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_{{protid}}_distribution_analysis.svg",
+        svg=FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_{protid}_distribution_analysis.svg"),
     conda:
         "envs/plotting.yml"
     benchmark:


### PR DESCRIPTION
Four small, independent fixes. This replaces #101, which was cut down after #103 landed: the `analysis.yml` matplotlib and setuptools pins are dropped because #103 took them verbatim, and the `python=3.9.16` pins are dropped for the reason below.

## The conda env cache `restore-keys` never matched

The key begins with `conda-` while the `restore-keys` begin with `snakemake-conda-`, so they never matched anything.

Correcting the prefix would be worse than removing them. A `restore-keys` match still leaves `cache-hit` false, so the env creation step runs regardless — and that step begins by deleting `.snakemake/conda`. Making the prefix match would therefore download a stale multi-gigabyte cache only to discard it: strictly slower than the broken prefix that never matched at all.

## `blastp` calls that fail but exit zero

When the remote server refuses to queue a request, `blastp -remote` reports the error on stderr, writes an empty results file, and still exits zero:

```
$ blastp -remote -db nr ... ; echo $?
Error: [blastp] bad_request: Could not queue request: DB operation failed.
0
```

`_run_blast_remote` printed that stderr but returned the zero exit code unchanged, so the caller treated the failure as a success. The word-size backoff was therefore never attempted — which is the situation it exists for — and the empty results file surfaced later in `extract_blast_hits.py` as a misleading "no hits were returned".

Failure is now determined by `blast_call_failed`, which also treats an error on stderr as a failure. An empty results file is deliberately *not* treated as a failure, because a query that legitimately has no hits produces one too.

This affects the `remote` backend only; the `www` backend does not shell out to `blastp`.

## Build the wildcard output paths without f-strings

Nested braces inside an f-string (`f"{ANALYSIS_NAME}_{{plotting_mode}}.html"`) tokenise differently under PEP 701 on Python 3.12+, and `snakefmt` then rewrites the Snakefile incorrectly. Building the paths without f-strings avoids depending on the interpreter version that happens to run the linter.

## On the python pins, and the mamba pin, that are *not* here

The earlier version of this branch also added `python=3.9.16` to `analysis.yml`, `plotting.yml` and `pandas.yml`, and pinned `mamba=1.4.2` in `cartography_test.yml`. Both are dropped, and the reason is worth recording because the first diagnosis was wrong.

The python pins were initially suspected of causing a large regression in env creation time. They were not the cause. **The mamba pin was.** Pinning `mamba=1.4.2` pulls `conda 23.3.1` and `libmamba 1.4.2` into the outer test environment, and the workflow then runs `snakemake --conda-frontend conda` against that older conda and its classic solver. Measured on CI:

| | `main` | this branch with the mamba pin |
| --- | --- | --- |
| mamba | unpinned, resolves to 2.9.0 | 1.4.2 |
| `analysis.yml` creation | 35s | over 15 minutes, then the runner was reclaimed |
| whole env creation step | 5m10s, succeeded | failed |

`analysis.yml` is byte-identical between the two, so the ~25x difference is entirely the solver that the outer environment supplies. The same pin was present on the earlier #101 and #102 branches and explains their env-creation failures too, which had been misattributed to the python pins.

The mamba pin was also fixing a path CI does not use: it exists to make `--conda-frontend mamba` work, and this workflow deliberately uses `--conda-frontend conda`. If that is worth solving it wants a different fix -- pinning conda rather than mamba -- and its own PR, with the timing above as the evidence.

The python pins are dropped on their own merits rather than as suspects: CI is green on `main` without them, since #103's targeted matplotlib and setuptools pins address the actual import failure. If they are still wanted for drift prevention, that is a separate PR.

With no `envs/` change left in this branch, the conda cache key now matches `main`, so this PR restores the cache hit instead of forcing a full env creation.

## Testing

`ruff` and `snakefmt` clean under CI's pinned versions on Python 3.9; unit tests pass, including four new ones covering the exit-zero case.

