### PR TITLE
Fix the CI conda cache, the Snakefile f-strings, and blastp calls that fail but exit zero

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,11 @@ jobs:
         with:
           path: .snakemake/conda
           key: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('envs/*.yml') }}
-          restore-keys: snakemake-conda-${{ runner.os }}--${{ runner.arch }}--
+          # note: there are deliberately no `restore-keys` here. A `restore-keys` match still
+          # leaves `cache-hit` false, so the step below runs anyway and begins by deleting
+          # `.snakemake/conda` -- meaning a partial match would download a stale multi-gigabyte
+          # cache only to discard it. (The `restore-keys` this replaces began with
+          # "snakemake-conda-" while the key begins with "conda-", so it never matched at all.)
 
       - name: Create the snakemake conda envs
         if: steps.cache-snakemake-conda-envs.outputs.cache-hit != 'true'

--- a/ProteinCartography/blast_utils.py
+++ b/ProteinCartography/blast_utils.py
@@ -33,6 +33,40 @@ from pathlib import Path
 
 NCBI_BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi"
 
+
+def blast_call_failed(result) -> bool:
+    """
+    Determine whether a call to the `blastp` CLI failed.
+
+    The exit code alone is not sufficient: when the remote server refuses to queue a request,
+    `blastp -remote` writes an error to stderr, writes an empty results file, and nevertheless
+    exits with a status of zero. For example:
+
+        Error: [blastp] bad_request: Could not queue request: DB operation failed.
+
+    Checking only the exit code therefore treats these failures as successes, which prevents the
+    word-size backoff in `run_blast.py` from ever being attempted and defers the failure to
+    `extract_blast_hits.py`, where it surfaces as a misleading "no hits were returned".
+
+    Note: an empty results file is deliberately *not* treated as a failure here, because a query
+    that legitimately has no hits also produces one.
+
+    Args:
+        result: the result of the call, with `returncode` and `stderr` attributes.
+
+    Returns:
+        True if the call failed.
+    """
+    if result.returncode != 0:
+        return True
+
+    stderr = result.stderr
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+
+    return "Error:" in (stderr or "")
+
+
 # Must match ``constants.BLAST_OUTPUT_FIELDS`` order after the leading ``6``
 # in ``BLAST_OUTFMT``.
 BLAST_TSV_FIELDS = [
@@ -504,4 +538,12 @@ def _run_blast_remote(
         if err_tail.strip():
             print(f"[blast] blastp stderr (tail):\n{err_tail}", flush=True)
     print(f"[blast] blastp finished rc={result.returncode}", flush=True)
+
+    # A refused request exits zero with the error only on stderr, so the exit code is reported
+    # back as a non-failure and the caller's word-size backoff never runs. Surface it as the
+    # failure it is, keeping the original stderr for the caller's error message.
+    if blast_call_failed(result) and result.returncode == 0:
+        print("[blast] blastp reported an error despite exiting zero; treating as a failure")
+        return BlastResult(returncode=1, stdout=result.stdout, stderr=result.stderr)
+
     return result

--- a/ProteinCartography/tests/test_blast_utils.py
+++ b/ProteinCartography/tests/test_blast_utils.py
@@ -49,3 +49,48 @@ def test_xml_to_blast_tsv_empty_without_blast_output(tmp_path: pathlib.Path):
     n = blast_utils._xml_to_blast_tsv("<html>waiting</html>", str(out))
     assert n == 0
     assert out.read_text() == ""
+
+
+# ------------------------------------------------------------------------------------------------
+# Detecting a `blastp -remote` call that failed but exited zero.
+# ------------------------------------------------------------------------------------------------
+
+
+class _Completed:
+    def __init__(self, returncode=0, stderr=b""):
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = b""
+
+
+def test_a_successful_call_did_not_fail():
+    assert not blast_utils.blast_call_failed(_Completed())
+
+
+def test_a_nonzero_exit_code_is_a_failure():
+    assert blast_utils.blast_call_failed(_Completed(returncode=1))
+
+
+def test_an_error_on_stderr_is_a_failure_despite_a_zero_exit_code():
+    """
+    The case this exists for: when the remote server refuses to queue the request, `blastp
+    -remote` reports the error, writes an empty results file, and still exits zero. Branching on
+    the exit code alone treats that as a success, so the word-size backoff never runs and the
+    failure surfaces later as a misleading "no hits were returned".
+    """
+    stderr = (
+        b"Error: [blastp] bad_request: Could not queue request: DB operation failed."
+        b"(ERR:-99  )((Severe Error) DB Put Request error: sp_NewRequestEx failed)\n"
+    )
+    assert blast_utils.blast_call_failed(_Completed(returncode=0, stderr=stderr))
+
+
+def test_a_warning_on_stderr_is_not_a_failure():
+    stderr = b"Warning: [blastp] Examining 5 or more matches is recommended\n"
+    assert not blast_utils.blast_call_failed(_Completed(returncode=0, stderr=stderr))
+
+
+def test_stderr_may_be_bytes_a_string_or_none():
+    assert blast_utils.blast_call_failed(_Completed(stderr="Error: something went wrong"))
+    assert not blast_utils.blast_call_failed(_Completed(stderr="all good"))
+    assert not blast_utils.blast_call_failed(_Completed(stderr=None))

--- a/ProteinCartography/tests/test_blast_utils.py
+++ b/ProteinCartography/tests/test_blast_utils.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 import pathlib
 
-import pytest
-
 import blast_utils
+import pytest
 
 
 def test_xml_to_blast_tsv_writes_sacc(tmp_path: pathlib.Path):

--- a/Snakefile
+++ b/Snakefile
@@ -636,7 +636,7 @@ rule plot_interactive:
         tm_scores=rules.dim_reduction.output.all_by_all_tmscores,
         features=rules.aggregate_features.output.aggregated_features,
     output:
-        html=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_aggregated_features_{{plotting_mode}}.html",
+        html=FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_aggregated_features_{plotting_mode}.html"),
     conda:
         "envs/plotting.yml"
     benchmark:
@@ -752,7 +752,7 @@ rule plot_cluster_distributions:
     input:
         features=rules.aggregate_features.output.aggregated_features,
     output:
-        svg=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_{{protid}}_distribution_analysis.svg",
+        svg=FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_{protid}_distribution_analysis.svg"),
     conda:
         "envs/plotting.yml"
     benchmark:


### PR DESCRIPTION
## Summary
- Rebases [mrubash1#108](https://github.com/Arcadia-Science/ProteinCartography/pull/108) onto current `main` after #107, keeping both the www timeout/error-page fixes and this PR's `blastp -remote` exit-zero detection.
- Drops the conda cache `restore-keys` that never matched (`snakemake-conda-` vs `conda-`) and would only download a stale cache to delete it.
- Treats `blastp -remote` stderr `Error:` as a failure even when the process exits 0, so the word-size backoff actually runs.
- Builds Snakefile wildcard output paths without f-strings so PEP 701 cannot rewrite the snakemake wildcards.

Original work by @mrubash1 in https://github.com/Arcadia-Science/ProteinCartography/pull/108.

## Test plan
- [x] Review of the original #108 diff (CI lint+test were already green)
- [ ] Confirm lint and test go green on this rebased branch
- [ ] After merge, close #108 as superseded by this PR


Made with [Cursor](https://cursor.com)