### PR TITLE
Add a gated parallel domain map that leaves the protein path unchanged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # packages installed in editable mode
 envs/src/**
 
+# Local git worktrees (never commit)
+.worktrees/
+
+# Local live-run fixtures (not part of the repo)
+/testdata/
+
 # Snakemake-related folders and files
 .snakemake/
 /input/

--- a/ProteinCartography/aggregate_domain_hits.py
+++ b/ProteinCartography/aggregate_domain_hits.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""Union domain-path BLAST/Foldseek hit lists and record which query domain found each hit."""
+
+from __future__ import annotations
+import argparse
+from collections import defaultdict
+from pathlib import Path
+
+import domain_utils as du
+
+__all__ = ["aggregate_domain_hits"]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i",
+        "--input",
+        nargs="+",
+        required=True,
+        help="Hit files named {domain_id}.blast_hits.uniprot.txt or {domain_id}.foldseek_hits.txt",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="Aggregated unique accessions, one per line.",
+    )
+    parser.add_argument(
+        "-f",
+        "--found-by",
+        required=True,
+        help="TSV of accession and found_by (comma-separated query domain ids).",
+    )
+    return parser.parse_args()
+
+
+def _domain_id_from_hit_file(path: str) -> str:
+    stem = Path(path).name
+    for suffix in (
+        ".blast_hits.uniprot.txt",
+        ".foldseek_hits.txt",
+        ".blast_hits.refseq.txt",
+    ):
+        if stem.endswith(suffix):
+            return stem[: -len(suffix)]
+    return Path(path).stem
+
+
+def aggregate_domain_hits(input_files: list, output_file: str, found_by_file: str) -> list[str]:
+    found_by: dict[str, set[str]] = defaultdict(set)
+    for file in input_files:
+        domain_id = _domain_id_from_hit_file(file)
+        try:
+            du.parse_domain_id(domain_id)
+        except ValueError:
+            domain_id = Path(file).stem
+        with open(file) as handle:
+            for line in handle:
+                acc = line.strip()
+                if not acc:
+                    continue
+                found_by[acc].add(domain_id)
+
+    accessions = sorted(found_by)
+    Path(output_file).write_text("".join(acc + "\n" for acc in accessions))
+    found_by_path = Path(found_by_file)
+    found_by_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["accession\tfound_by\n"]
+    for acc in accessions:
+        sources = ",".join(sorted(found_by[acc]))
+        lines.append(f"{acc}\t{sources}\n")
+    found_by_path.write_text("".join(lines))
+    return accessions
+
+
+def main():
+    args = parse_args()
+    aggregate_domain_hits(args.input, args.output, args.found_by)
+
+
+if __name__ == "__main__":
+    main()

--- a/ProteinCartography/aggregate_features.py
+++ b/ProteinCartography/aggregate_features.py
@@ -70,7 +70,7 @@ def aggregate_features(
             agg_df = agg_df.merge(df, on="protid", how="outer")
 
     # If there's a features override file, use it
-    if features_override_file is not None:
+    if features_override_file:
         # Read the file
         features_override_df = pd.read_csv(features_override_file, sep="\t")
 

--- a/ProteinCartography/api_utils.py
+++ b/ProteinCartography/api_utils.py
@@ -60,7 +60,7 @@ class DefaultExpBackoffRetry(Retry):
             "read": 5,
             "connect": 5,
             "backoff_factor": 2,
-            "status_forcelist": (500, 502, 503, 504),
+            "status_forcelist": (429, 500, 502, 503, 504),
             "allowed_methods": frozenset({"GET", "PUT", "POST"}),
         }
 

--- a/ProteinCartography/assign_domains.py
+++ b/ProteinCartography/assign_domains.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python
+"""Assign TED/user domain boundaries and crop query or hit structures.
+
+Query-gate: TED (or a user TSV) on query proteins only. The domain DAG runs
+only when at least one query has two or more kept domains. TED failures on a
+query never fail the protein pipeline.
+
+Hit assignment: TED on domain-path hit accessions; misses are omitted.
+"""
+
+from __future__ import annotations
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+import domain_utils as du
+
+# If necessary, mock the web API responses (see ``tests.mocks``).
+if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
+    from tests import mocks
+
+    mocks.mock_requests_session_request()
+
+__all__ = [
+    "fetch_ted_summary",
+    "load_user_domains",
+    "assign_parent",
+    "run_query_gate",
+    "assign_and_crop_hits",
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gate = sub.add_parser("query-gate", help="Assign query domains and write the gate files.")
+    gate.add_argument("--protids", nargs="+", required=True, help="Query protein ids.")
+    gate.add_argument("--input-dir", required=True, help="Directory with query FASTA/PDB files.")
+    gate.add_argument("--output-dir", required=True, help="Domain-path directory to write.")
+    gate.add_argument("--user-domains-file", default="", help="Optional user domain TSV.")
+    gate.add_argument(
+        "--min-domain-length",
+        type=int,
+        default=du.DEFAULT_MIN_DOMAIN_LENGTH,
+    )
+    gate.add_argument(
+        "--domain-map",
+        default="auto",
+        choices=["auto", "off"],
+    )
+
+    hits = sub.add_parser("assign-hits", help="TED-assign and crop domain-path hit PDBs.")
+    hits.add_argument("--accessions-file", required=True, help="One UniProt accession per line.")
+    hits.add_argument("--pdb-dir", required=True, help="Directory of downloaded full-length PDBs.")
+    hits.add_argument("--output-dir", required=True, help="Directory for cropped domain PDBs.")
+    hits.add_argument("--output-tsv", required=True, help="Path to domain_features.tsv.")
+    hits.add_argument("--cache-dir", required=True, help="TED JSON cache directory.")
+    hits.add_argument(
+        "--min-domain-length",
+        type=int,
+        default=du.DEFAULT_MIN_DOMAIN_LENGTH,
+    )
+    hits.add_argument(
+        "--query-domains-tsv",
+        default="",
+        help="Query domain rows to prepend so query domains are always on the map.",
+    )
+    hits.add_argument(
+        "--query-structures-dir",
+        default="",
+        help="Directory of already-cropped query domain PDBs to copy into output-dir.",
+    )
+    hits.add_argument("--user-domains-file", default="")
+
+    return parser.parse_args()
+
+
+def _ted_rate_limited_get(session, url: str, timeout: int = 60):
+    """GET with the same polite rate limit pattern as download_pdbs."""
+    try:
+        from ratelimiter import RateLimiter
+    except ImportError:
+        return session.get(url, timeout=timeout)
+
+    limiter = getattr(_ted_rate_limited_get, "_limiter", None)
+    if limiter is None:
+        limiter = RateLimiter(max_calls=10, period=1)
+        _ted_rate_limited_get._limiter = limiter
+    with limiter:
+        return session.get(url, timeout=timeout)
+
+
+def _ted_get_page(session, acc: str, skip: int, limit: int) -> dict | None:
+    """Fetch one TED summary page. 429 is retried; other errors return None."""
+    url = du.TED_SUMMARY_URL.format(acc=acc) + f"?skip={skip}&limit={limit}"
+    last_status = None
+    for attempt in range(1, du.TED_MAX_429_RETRIES + 1):
+        try:
+            response = _ted_rate_limited_get(session, url, timeout=60)
+        except Exception as exc:
+            print(f"[assign_domains] TED request failed for {acc}: {exc}", file=sys.stderr)
+            return None
+
+        last_status = getattr(response, "status_code", None)
+        if last_status == 429:
+            print(
+                f"[assign_domains] TED HTTP 429 for {acc} (attempt {attempt}/"
+                f"{du.TED_MAX_429_RETRIES}); retrying",
+                file=sys.stderr,
+            )
+            continue
+        if last_status == 404:
+            return {"data": [], "count": 0}
+        if not getattr(response, "ok", False) or (last_status is not None and last_status >= 400):
+            print(
+                f"[assign_domains] TED HTTP {last_status} for {acc}; treating as miss",
+                file=sys.stderr,
+            )
+            return None
+        try:
+            payload = response.json()
+        except Exception as exc:
+            print(f"[assign_domains] TED JSON error for {acc}: {exc}", file=sys.stderr)
+            return None
+        if not isinstance(payload, dict):
+            payload = {"data": payload or [], "count": 0}
+        return payload
+
+    print(
+        f"[assign_domains] TED HTTP {last_status} for {acc} after retries; treating as miss",
+        file=sys.stderr,
+    )
+    return None
+
+
+def fetch_ted_summary(accession: str, session, cache_dir: Path) -> dict | None:
+    """Return a TED summary payload or None on miss/error. Caches successful GETs and 404s.
+
+    Pages with skip/limit until a short page is returned. ``count`` on the API is the
+    page size, not a total, so pagination stops on a short page rather than count.
+    """
+    acc = du.canonical_uniprot_accession(accession)
+    cached = du.load_ted_cache(cache_dir, acc)
+    if cached is not None:
+        return cached
+
+    all_data: list = []
+    skip = 0
+    while True:
+        payload = _ted_get_page(session, acc, skip, du.TED_PAGE_SIZE)
+        if payload is None:
+            if skip == 0:
+                return None
+            break
+        data = payload.get("data") or []
+        all_data.extend(data)
+        if len(data) < du.TED_PAGE_SIZE:
+            break
+        skip += du.TED_PAGE_SIZE
+
+    merged = {"data": all_data, "count": len(all_data)}
+    du.save_ted_cache(cache_dir, acc, merged)
+    return merged
+
+
+def load_user_domains(path: str) -> dict[str, list[dict]]:
+    """Map parent_protid → domain rows from an optional user TSV."""
+    if not path:
+        return {}
+    user_path = Path(path)
+    if not user_path.is_file():
+        return {}
+    with user_path.open(newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        records = list(reader)
+    rows = du.rows_from_user_tsv_records(records)
+    by_parent: dict[str, list[dict]] = {}
+    for row in rows:
+        by_parent.setdefault(row["parent_protid"], []).append(row)
+    return by_parent
+
+
+def assign_parent(
+    parent_protid: str,
+    session,
+    cache_dir: Path,
+    user_by_parent: dict[str, list[dict]],
+    min_domain_length: int,
+) -> list[dict]:
+    """User TSV wins; else TED; else empty. Never raises."""
+    if parent_protid in user_by_parent:
+        return du.filter_domain_rows(user_by_parent[parent_protid], min_domain_length)
+
+    if not du.looks_like_uniprot_accession(parent_protid):
+        return []
+
+    payload = fetch_ted_summary(parent_protid, session, cache_dir)
+    if not payload:
+        return []
+    rows = du.rows_from_ted_payload(parent_protid, payload)
+    return du.filter_domain_rows(rows, min_domain_length)
+
+
+def _write_domains_tsv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=du.DOMAIN_FEATURES_COLUMNS, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({col: row.get(col, "") for col in du.DOMAIN_FEATURES_COLUMNS})
+
+
+def _crop_query_files(parent: str, rows: list[dict], input_dir: Path, query_structures: Path):
+    fasta = input_dir / f"{parent}.fasta"
+    pdb = input_dir / f"{parent}.pdb"
+    for row in rows:
+        domain_id = row["protid"]
+        chopping = row["chopping"]
+        if fasta.is_file():
+            du.crop_fasta_file(fasta, chopping, query_structures / f"{domain_id}.fasta", domain_id)
+        if pdb.is_file():
+            dest = query_structures / f"{domain_id}.pdb"
+            n_ca = du.crop_pdb_file(pdb, chopping, dest)
+            row["nres_domain"] = n_ca
+            if n_ca <= 0:
+                dest.unlink(missing_ok=True)
+                fasta_out = query_structures / f"{domain_id}.fasta"
+                if fasta_out.is_file():
+                    fasta_out.unlink()
+
+
+def run_query_gate(
+    protids: list[str],
+    input_dir: str,
+    output_dir: str,
+    user_domains_file: str = "",
+    min_domain_length: int = du.DEFAULT_MIN_DOMAIN_LENGTH,
+    domain_map: str = "auto",
+    session=None,
+) -> str:
+    """Write gate.txt, query_domains.tsv, query_domain_ids.txt, and cropped query files.
+
+    Returns ``\"on\"`` or ``\"off\"``.
+    """
+    output = Path(output_dir)
+    cache_dir = output / "ted_cache"
+    query_structures = output / "query_structures"
+    query_structures.mkdir(parents=True, exist_ok=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    gate_path = output / "gate.txt"
+    ids_path = output / "query_domain_ids.txt"
+    tsv_path = output / "query_domains.tsv"
+
+    if str(domain_map).lower() == "off":
+        gate_path.write_text("off\n")
+        ids_path.write_text("")
+        _write_domains_tsv(tsv_path, [])
+        return "off"
+
+    if session is None:
+        from api_utils import session_with_retry
+
+        session = session_with_retry()
+    user_by_parent = load_user_domains(user_domains_file)
+
+    multi_rows: list[dict] = []
+    for parent in protids:
+        rows = assign_parent(parent, session, cache_dir, user_by_parent, min_domain_length)
+        if not du.is_multidomain(len(rows)):
+            continue
+        _crop_query_files(parent, rows, Path(input_dir), query_structures)
+        cropped = [row for row in rows if int(row.get("nres_domain") or 0) > 0]
+        if du.is_multidomain(len(cropped)):
+            multi_rows.extend(cropped)
+
+    gate = "on" if multi_rows else "off"
+    gate_path.write_text(gate + "\n")
+    ids_path.write_text("".join(row["protid"] + "\n" for row in multi_rows))
+    _write_domains_tsv(tsv_path, multi_rows)
+    return gate
+
+
+def assign_and_crop_hits(
+    accessions_file: str,
+    pdb_dir: str,
+    output_dir: str,
+    output_tsv: str,
+    cache_dir: str,
+    min_domain_length: int = du.DEFAULT_MIN_DOMAIN_LENGTH,
+    query_domains_tsv: str = "",
+    query_structures_dir: str = "",
+    user_domains_file: str = "",
+    session=None,
+) -> list[dict]:
+    """TED-assign hit PDBs, omit misses, crop survivors, prepend query domain rows."""
+    if session is None:
+        from api_utils import session_with_retry
+
+        session = session_with_retry()
+    user_by_parent = load_user_domains(user_domains_file)
+    pdb_dir_path = Path(pdb_dir)
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cache = Path(cache_dir)
+    cache.mkdir(parents=True, exist_ok=True)
+
+    accessions = [
+        line.strip() for line in Path(accessions_file).read_text().splitlines() if line.strip()
+    ]
+
+    query_rows: list[dict] = []
+    query_parents: set[str] = set()
+    if query_domains_tsv and Path(query_domains_tsv).is_file():
+        with Path(query_domains_tsv).open(newline="") as handle:
+            query_rows = list(csv.DictReader(handle, delimiter="\t"))
+        query_parents = {
+            str(row.get("parent_protid", "")).strip()
+            for row in query_rows
+            if str(row.get("parent_protid", "")).strip()
+        }
+        query_src = Path(query_structures_dir) if query_structures_dir else None
+        for row in query_rows:
+            dest = out_dir / f"{row['protid']}.pdb"
+            src = (query_src / f"{row['protid']}.pdb") if query_src else None
+            if src is not None and src.is_file() and not dest.exists():
+                dest.write_text(src.read_text())
+
+    hit_rows: list[dict] = []
+    for acc in accessions:
+        if acc in query_parents:
+            continue
+        rows = assign_parent(acc, session, cache, user_by_parent, min_domain_length)
+        if not rows:
+            print(f"[assign_domains] omitting hit {acc}: no TED/user domains", file=sys.stderr)
+            continue
+        pdb_path = pdb_dir_path / f"{acc}.pdb"
+        if not pdb_path.is_file():
+            print(f"[assign_domains] omitting hit {acc}: missing PDB", file=sys.stderr)
+            continue
+        for row in rows:
+            dest = out_dir / f"{row['protid']}.pdb"
+            n_ca = du.crop_pdb_file(pdb_path, row["chopping"], dest)
+            if n_ca <= 0:
+                dest.unlink(missing_ok=True)
+                print(
+                    f"[assign_domains] omitting {row['protid']}: empty crop for {acc}",
+                    file=sys.stderr,
+                )
+                continue
+            row["nres_domain"] = n_ca
+            hit_rows.append(row)
+
+    all_rows = query_rows + hit_rows
+    # DictReader values are strings; normalize types for the TSV writer.
+    normalized = []
+    for row in all_rows:
+        normalized.append(
+            {
+                col: row.get(col, "")
+                if col not in {"domain_index", "start", "end", "nres_domain"}
+                else int(row[col])
+                if str(row.get(col, "")).strip()
+                else ""
+                for col in du.DOMAIN_FEATURES_COLUMNS
+            }
+        )
+    _write_domains_tsv(Path(output_tsv), normalized)
+    return normalized
+
+
+def main():
+    args = parse_args()
+    if args.command == "query-gate":
+        run_query_gate(
+            protids=args.protids,
+            input_dir=args.input_dir,
+            output_dir=args.output_dir,
+            user_domains_file=args.user_domains_file,
+            min_domain_length=args.min_domain_length,
+            domain_map=args.domain_map,
+        )
+    elif args.command == "assign-hits":
+        assign_and_crop_hits(
+            accessions_file=args.accessions_file,
+            pdb_dir=args.pdb_dir,
+            output_dir=args.output_dir,
+            output_tsv=args.output_tsv,
+            cache_dir=args.cache_dir,
+            min_domain_length=args.min_domain_length,
+            query_domains_tsv=args.query_domains_tsv,
+            query_structures_dir=args.query_structures_dir,
+            user_domains_file=args.user_domains_file,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ProteinCartography/config_utils.py
+++ b/ProteinCartography/config_utils.py
@@ -119,3 +119,31 @@ def _get_features_override_file(config):
     if not features_override_file.is_file():
         features_override_file = ""
     return features_override_file
+
+
+def _get_domain_map(config) -> str:
+    """``auto`` (default) runs the domain DAG only for multi-domain queries; ``off`` never does."""
+    value = str(config.get("domain_map", "auto")).strip().lower()
+    if value not in {"auto", "off"}:
+        raise ProteinCartographyInputError("domain_map must be 'auto' or 'off'.")
+    return value
+
+
+def _get_user_domains_file(config) -> str:
+    """Optional TSV of parent_protid + chopping (or start/end). Empty string if unset."""
+    name = config.get("user_domains_file") or ""
+    if not name:
+        return ""
+    path = pathlib.Path(config["input_dir"]) / name
+    if not path.is_file():
+        raise ProteinCartographyInputError(
+            f"user_domains_file {path} does not exist. The file is resolved relative to input_dir."
+        )
+    return str(path)
+
+
+def _get_min_domain_length(config) -> int:
+    try:
+        return int(config.get("min_domain_length", 30))
+    except (TypeError, ValueError):
+        return 30

--- a/ProteinCartography/domain_utils.py
+++ b/ProteinCartography/domain_utils.py
@@ -1,0 +1,289 @@
+"""Domain identity, TED chopping, FASTA/PDB cropping, and the multi-domain gate.
+
+The protein pipeline does not import this module. Domain-map code uses it to
+turn a parent protein into ``{parent}__d01``-style domain instances.
+"""
+
+from __future__ import annotations
+import json
+import re
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+DOMAIN_ID_SEP = "__d"
+DOMAIN_ID_PATTERN = re.compile(r"^(?P<parent>.+)" + DOMAIN_ID_SEP + r"(?P<index>\d+)$")
+CHOPPING_SEGMENT = re.compile(r"^(\d+)-(\d+)$")
+# Canonical UniProtKB accessions (6 or 10 characters), optional isoform suffix.
+UNIPROT_ACCESSION = re.compile(
+    r"^(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9][A-Z][A-Z0-9]{2}[0-9]"
+    r"|A0A[A-Z0-9]{7})(?:-\d+)?$"
+)
+
+DOMAIN_FEATURES_COLUMNS = [
+    "protid",
+    "parent_protid",
+    "domain_index",
+    "chopping",
+    "start",
+    "end",
+    "nres_domain",
+    "assignment_source",
+    "ted_id",
+    "cath_label",
+]
+
+DEFAULT_MIN_DOMAIN_LENGTH = 30
+TED_SUMMARY_URL = "https://ted.cathdb.info/api/v1/uniprot/summary/{acc}"
+TED_PAGE_SIZE = 50
+TED_MAX_429_RETRIES = 5
+
+
+class DomainChoppingError(ValueError):
+    """Raised when a TED/user chopping string cannot be parsed."""
+
+
+def parse_chopping(chopping: str) -> list[tuple[int, int]]:
+    """Parse a TED chopping into 1-based inclusive ``(start, end)`` segments.
+
+    Continuous: ``\"22-141\"``. Discontinuous: ``\"22-50_80-120\"``.
+    """
+    if not chopping or not str(chopping).strip():
+        raise DomainChoppingError("empty chopping")
+    segments: list[tuple[int, int]] = []
+    for part in str(chopping).strip().split("_"):
+        match = CHOPPING_SEGMENT.match(part)
+        if not match:
+            raise DomainChoppingError(f"invalid chopping segment: {part!r} in {chopping!r}")
+        start, end = int(match.group(1)), int(match.group(2))
+        if start < 1 or end < start:
+            raise DomainChoppingError(f"invalid residue range {start}-{end} in {chopping!r}")
+        segments.append((start, end))
+    return segments
+
+
+def chopping_nres(segments: Sequence[tuple[int, int]]) -> int:
+    return sum(end - start + 1 for start, end in segments)
+
+
+def residue_in_segments(resseq: int, segments: Sequence[tuple[int, int]]) -> bool:
+    return any(start <= resseq <= end for start, end in segments)
+
+
+def make_domain_id(parent_protid: str, domain_index: int) -> str:
+    if domain_index < 1:
+        raise ValueError("domain_index is 1-based")
+    return f"{parent_protid}{DOMAIN_ID_SEP}{domain_index:02d}"
+
+
+def parse_domain_id(domain_id: str) -> tuple[str, int]:
+    match = DOMAIN_ID_PATTERN.match(domain_id)
+    if not match:
+        raise ValueError(f"not a domain id: {domain_id!r}")
+    return match.group("parent"), int(match.group("index"))
+
+
+def looks_like_uniprot_accession(protid: str) -> bool:
+    return bool(UNIPROT_ACCESSION.match(protid))
+
+
+def canonical_uniprot_accession(protid: str) -> str:
+    """Strip an isoform suffix so TED can be queried with the canonical acc."""
+    if "-" in protid and looks_like_uniprot_accession(protid):
+        return protid.rsplit("-", 1)[0]
+    return protid
+
+
+def is_multidomain(n_kept_domains: int) -> bool:
+    return n_kept_domains >= 2
+
+
+def keep_domain(nres: int, min_domain_length: int = DEFAULT_MIN_DOMAIN_LENGTH) -> bool:
+    return nres >= min_domain_length
+
+
+def domain_row(
+    parent_protid: str,
+    domain_index: int,
+    chopping: str,
+    assignment_source: str,
+    ted_id: str = "",
+    cath_label: str = "",
+    nres_domain: int | None = None,
+) -> dict:
+    segments = parse_chopping(chopping)
+    nres = chopping_nres(segments) if nres_domain is None else int(nres_domain)
+    return {
+        "protid": make_domain_id(parent_protid, domain_index),
+        "parent_protid": parent_protid,
+        "domain_index": domain_index,
+        "chopping": chopping,
+        "start": segments[0][0],
+        "end": segments[-1][1],
+        "nres_domain": nres,
+        "assignment_source": assignment_source,
+        "ted_id": ted_id or "",
+        "cath_label": cath_label or "",
+    }
+
+
+def filter_domain_rows(
+    rows: Iterable[dict], min_domain_length: int = DEFAULT_MIN_DOMAIN_LENGTH
+) -> list[dict]:
+    kept = [row for row in rows if keep_domain(int(row["nres_domain"]), min_domain_length)]
+    # Re-number domain_index / protid after filtering so ids stay contiguous.
+    renumbered = []
+    by_parent: dict[str, list[dict]] = {}
+    for row in kept:
+        by_parent.setdefault(row["parent_protid"], []).append(row)
+    for parent, parent_rows in by_parent.items():
+        for i, row in enumerate(parent_rows, start=1):
+            updated = dict(row)
+            updated["domain_index"] = i
+            updated["protid"] = make_domain_id(parent, i)
+            renumbered.append(updated)
+    return renumbered
+
+
+def parse_fasta(text: str) -> tuple[str, str]:
+    lines = [line.rstrip("\n") for line in text.splitlines() if line.strip()]
+    if not lines or not lines[0].startswith(">"):
+        raise ValueError("FASTA must start with a '>' header")
+    header = lines[0][1:].split()[0]
+    sequence = "".join(lines[1:]).replace(" ", "").replace("\r", "")
+    return header, sequence
+
+
+def slice_fasta_sequence(sequence: str, chopping: str) -> str:
+    """Slice a protein sequence with 1-based inclusive UniProt numbering."""
+    parts = []
+    for start, end in parse_chopping(chopping):
+        if end > len(sequence):
+            raise ValueError(f"chopping {start}-{end} exceeds sequence length {len(sequence)}")
+        parts.append(sequence[start - 1 : end])
+    return "".join(parts)
+
+
+def write_fasta(path: Path, seq_id: str, sequence: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    wrapped = "\n".join(sequence[i : i + 60] for i in range(0, len(sequence), 60))
+    path.write_text(f">{seq_id}\n{wrapped}\n")
+
+
+def _pdb_resseq(line: str) -> int | None:
+    if len(line) < 26:
+        return None
+    if not line.startswith("ATOM") and not line.startswith("HETATM"):
+        return None
+    raw = line[22:26]
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _is_c_alpha(line: str) -> bool:
+    if len(line) < 16:
+        return False
+    return line.startswith("ATOM") and line[12:16].strip() == "CA"
+
+
+def crop_pdb_text(pdb_text: str, chopping: str) -> tuple[str, int]:
+    """Keep ATOM/HETATM records whose residue sequence number is in ``chopping``.
+
+    Returns ``(cropped_pdb, n_c_alpha)``. Residue numbers are PDB ``resSeq``
+    fields (author/UniProt numbering), not atom serials or list indices.
+    """
+    segments = parse_chopping(chopping)
+    kept_lines = []
+    ca_resseqs = set()
+    for line in pdb_text.splitlines():
+        resseq = _pdb_resseq(line)
+        if resseq is None:
+            continue
+        if residue_in_segments(resseq, segments):
+            kept_lines.append(line.rstrip("\n"))
+            if _is_c_alpha(line):
+                ca_resseqs.add(resseq)
+    kept_lines.append("END")
+    return "\n".join(kept_lines) + "\n", len(ca_resseqs)
+
+
+def crop_pdb_file(pdb_path: Path, chopping: str, output_path: Path) -> int:
+    text = pdb_path.read_text(errors="replace")
+    cropped, n_ca = crop_pdb_text(text, chopping)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(cropped)
+    return n_ca
+
+
+def crop_fasta_file(fasta_path: Path, chopping: str, output_path: Path, seq_id: str) -> str:
+    _, sequence = parse_fasta(fasta_path.read_text())
+    sliced = slice_fasta_sequence(sequence, chopping)
+    write_fasta(output_path, seq_id, sliced)
+    return sliced
+
+
+def ted_cache_path(cache_dir: Path, accession: str) -> Path:
+    return Path(cache_dir) / f"{accession}.ted.json"
+
+
+def load_ted_cache(cache_dir: Path, accession: str) -> dict | None:
+    path = ted_cache_path(cache_dir, accession)
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text())
+
+
+def save_ted_cache(cache_dir: Path, accession: str, payload: dict) -> None:
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    ted_cache_path(cache_dir, accession).write_text(json.dumps(payload))
+
+
+def rows_from_ted_payload(parent_protid: str, payload: dict) -> list[dict]:
+    data = payload.get("data") or []
+    rows = []
+    for i, item in enumerate(data, start=1):
+        chopping = item.get("chopping") or ""
+        if not chopping:
+            continue
+        rows.append(
+            domain_row(
+                parent_protid=parent_protid,
+                domain_index=i,
+                chopping=chopping,
+                assignment_source="ted",
+                ted_id=item.get("ted_id") or "",
+                cath_label=item.get("cath_label") or "",
+                nres_domain=item.get("nres_domain"),
+            )
+        )
+    return rows
+
+
+def rows_from_user_tsv_records(records: Iterable[dict]) -> list[dict]:
+    """Build domain rows from user TSV dicts with ``parent_protid`` and chopping/start-end."""
+    grouped: dict[str, list[dict]] = {}
+    for rec in records:
+        parent = str(rec["parent_protid"]).strip()
+        if rec.get("chopping"):
+            chopping = str(rec["chopping"]).strip()
+        else:
+            chopping = f"{int(rec['start'])}-{int(rec['end'])}"
+        grouped.setdefault(parent, []).append({"chopping": chopping, **rec})
+
+    rows = []
+    for parent, items in grouped.items():
+        for i, item in enumerate(items, start=1):
+            index = int(item["domain_index"]) if item.get("domain_index") else i
+            rows.append(
+                domain_row(
+                    parent_protid=parent,
+                    domain_index=index,
+                    chopping=item["chopping"],
+                    assignment_source="user",
+                    ted_id=str(item.get("ted_id") or ""),
+                    cath_label=str(item.get("cath_label") or ""),
+                )
+            )
+    return rows

--- a/ProteinCartography/extract_foldseek_hits.py
+++ b/ProteinCartography/extract_foldseek_hits.py
@@ -113,7 +113,12 @@ def main():
     evalue = args.evalue
     max_num_hits = args.max_num_hits
 
-    # send to map_refseqids
+    if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
+        from tests import mocks
+
+        if mocks.maybe_write_per_domain_hits(output_file):
+            return
+
     extract_foldseekhits(input_files, output_file, evalue=evalue, max_num_hits=max_num_hits)
 
 

--- a/ProteinCartography/extract_foldseek_hits.py
+++ b/ProteinCartography/extract_foldseek_hits.py
@@ -114,9 +114,9 @@ def main():
     max_num_hits = args.max_num_hits
 
     if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
-        from tests import mocks
+        from tests.mock_domain_hits import maybe_write_per_domain_hits
 
-        if mocks.maybe_write_per_domain_hits(output_file):
+        if maybe_write_per_domain_hits(output_file):
             return
 
     extract_foldseekhits(input_files, output_file, evalue=evalue, max_num_hits=max_num_hits)

--- a/ProteinCartography/join_domain_features.py
+++ b/ProteinCartography/join_domain_features.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Join UniProt protein metadata onto domain rows via parent_protid.
+
+Domain ``protid`` stays the domain id. UniProt columns (Protein names, Organism,
+...) are copied from the parent accession so existing plot/semantic scripts work.
+"""
+
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+__all__ = ["join_domain_uniprot"]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--domain-features", required=True)
+    parser.add_argument("--uniprot-features", required=True)
+    parser.add_argument("--found-by", default="", help="Optional accession\\tfound_by TSV.")
+    parser.add_argument("--output", required=True)
+    return parser.parse_args()
+
+
+def join_domain_uniprot(
+    domain_features: str,
+    uniprot_features: str,
+    output_file: str,
+    found_by_file: str = "",
+) -> pd.DataFrame:
+    domain_df = pd.read_csv(domain_features, sep="\t")
+    uniprot_path = Path(uniprot_features)
+    if uniprot_path.is_file() and uniprot_path.stat().st_size > 0:
+        uniprot_df = pd.read_csv(uniprot_path, sep="\t")
+        if "protid" in uniprot_df.columns:
+            uniprot_df = uniprot_df.rename(columns={"protid": "parent_protid"})
+            overlap = [
+                c for c in uniprot_df.columns if c in domain_df.columns and c != "parent_protid"
+            ]
+            uniprot_df = uniprot_df.drop(columns=overlap)
+            domain_df = domain_df.merge(uniprot_df, on="parent_protid", how="left")
+
+    if found_by_file and Path(found_by_file).is_file():
+        found_df = pd.read_csv(found_by_file, sep="\t")
+        if "accession" in found_df.columns:
+            found_df = found_df.rename(columns={"accession": "parent_protid"})
+            domain_df = domain_df.merge(found_df, on="parent_protid", how="left")
+
+    # Domain map Length is the cropped domain, not the parent chain.
+    if "nres_domain" in domain_df.columns:
+        domain_df["Length"] = domain_df["nres_domain"]
+
+    domain_df.to_csv(output_file, sep="\t", index=False)
+    return domain_df
+
+
+def main():
+    args = parse_args()
+    join_domain_uniprot(
+        args.domain_features, args.uniprot_features, args.output, found_by_file=args.found_by
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ProteinCartography/map_refseq_ids.py
+++ b/ProteinCartography/map_refseq_ids.py
@@ -209,6 +209,11 @@ def map_refseqids_rest(input_file: str, output_file: str, query_dbs: list, retur
 
 def main():
     args = parse_args()
+    if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
+        from tests import mocks
+
+        if mocks.maybe_write_per_domain_hits(args.output):
+            return
     service = UniProtService(args.service)
     if service == UniProtService.BIOSERVICES:
         map_refseqids_bioservices(args.input, args.output, args.databases)

--- a/ProteinCartography/map_refseq_ids.py
+++ b/ProteinCartography/map_refseq_ids.py
@@ -210,9 +210,9 @@ def map_refseqids_rest(input_file: str, output_file: str, query_dbs: list, retur
 def main():
     args = parse_args()
     if os.environ.get("PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS") == "true":
-        from tests import mocks
+        from tests.mock_domain_hits import maybe_write_per_domain_hits
 
-        if mocks.maybe_write_per_domain_hits(args.output):
+        if maybe_write_per_domain_hits(args.output):
             return
     service = UniProtService(args.service)
     if service == UniProtService.BIOSERVICES:

--- a/ProteinCartography/plot_interactive.py
+++ b/ProteinCartography/plot_interactive.py
@@ -247,6 +247,38 @@ def generate_plotting_rules(
             "fillna": "",
             "textlabel": "Protein name",
         },
+        "parent_protid": {
+            "type": "hovertext",
+            "fillna": "",
+            "textlabel": "Parent protein",
+        },
+        "chopping": {
+            "type": "hovertext",
+            "fillna": "",
+            "textlabel": "Domain residues",
+        },
+        "ted_id": {
+            "type": "hovertext",
+            "fillna": "",
+            "textlabel": "TED id",
+        },
+        "cath_label": {
+            "type": "categorical",
+            "fillna": "None",
+            "color_order": apc.Palettes["arcadia:AccentAllOrdered"].colors,
+            "textlabel": "CATH / TED superfamily",
+        },
+        "assignment_source": {
+            "type": "categorical",
+            "fillna": "None",
+            "color_order": apc.Palettes["arcadia:AccentAllOrdered"].colors,
+            "textlabel": "Domain assignment",
+        },
+        "found_by": {
+            "type": "hovertext",
+            "fillna": "",
+            "textlabel": "Retrieved by query domain",
+        },
         "Gene Names (primary)": {
             "type": "hovertext",  # this data only shows up in hovertext
             "fillna": "",
@@ -328,24 +360,26 @@ def generate_plotting_rules(
                 "cmin": 0,
                 "cmax": 1,
             }
-            plotting_rules[f"fident_v_{keyid}"] = {
-                "type": "continuous",
-                "apply": lambda x: round(x, num_decimals),
-                "fillna": -0.01,
-                "textlabel": f"Fraction seq identity vs. {keyid}",
-                "color_scale": arcadia_magma,
-                "cmin": 0,
-                "cmax": 1,
-            }
-            plotting_rules[f"concordance_v_{keyid}"] = {
-                "type": "continuous",
-                "apply": lambda x: round(x, num_decimals),
-                "fillna": -1.01,
-                "textlabel": f"Concordance vs. {keyid}",
-                "color_scale": arcadia_poppies_r,
-                "cmin": -1,
-                "cmax": 1,
-            }
+            # Domain maps only color by TM-score vs query domains (no fident/concordance layers).
+            if "__d" not in str(keyid):
+                plotting_rules[f"fident_v_{keyid}"] = {
+                    "type": "continuous",
+                    "apply": lambda x: round(x, num_decimals),
+                    "fillna": -0.01,
+                    "textlabel": f"Fraction seq identity vs. {keyid}",
+                    "color_scale": arcadia_magma,
+                    "cmin": 0,
+                    "cmax": 1,
+                }
+                plotting_rules[f"concordance_v_{keyid}"] = {
+                    "type": "continuous",
+                    "apply": lambda x: round(x, num_decimals),
+                    "fillna": -1.01,
+                    "textlabel": f"Concordance vs. {keyid}",
+                    "color_scale": arcadia_poppies_r,
+                    "cmin": -1,
+                    "cmax": 1,
+                }
             # Add hovertext for whether or not a given protein was a hit via blast or foldseek
             # to the input protein
             plotting_rules[f"{keyid}.hit"] = {

--- a/ProteinCartography/tests/mock_domain_hits.py
+++ b/ProteinCartography/tests/mock_domain_hits.py
@@ -1,0 +1,28 @@
+"""Domain-path mock hit lists. Kept free of ``requests`` so pandas-env scripts can import it."""
+
+from pathlib import Path
+
+# Distinct domain-path neighborhoods used by the two-domain Snakemake test.
+# These accessions have AlphaFold artifacts. Protein-path mocks still return the
+# full actin hit list, so a parent-PDB search that only relabels outputs cannot
+# produce this partitioned union.
+DOMAIN_SEARCH_HITS = {
+    "d01": ["A0A286Q506"],
+    "d02": ["Q6QAQ1"],
+}
+
+
+def maybe_write_per_domain_hits(output_file: str) -> bool:
+    """If ``output_file`` is a domain-path hit list, write that domain's neighborhood.
+
+    Returns True when the caller should skip normal extraction.
+    """
+    name = output_file.replace("\\", "/")
+    for suffix, hits in DOMAIN_SEARCH_HITS.items():
+        token = f"__{suffix}."
+        if token in name or name.endswith(f"__{suffix}"):
+            path = Path(output_file)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("".join(hit + "\n" for hit in hits))
+            return True
+    return False

--- a/ProteinCartography/tests/mocks.py
+++ b/ProteinCartography/tests/mocks.py
@@ -37,34 +37,6 @@ def mock_run_blast():
     patch.start()
 
 
-# Distinct domain-path neighborhoods used by the two-domain Snakemake test.
-# These accessions have AlphaFold artifacts. Protein-path mocks still return the
-# full actin hit list, so a parent-PDB search that only relabels outputs cannot
-# produce this partitioned union.
-DOMAIN_SEARCH_HITS = {
-    "d01": ["A0A286Q506"],
-    "d02": ["Q6QAQ1"],
-}
-
-
-def maybe_write_per_domain_hits(output_file: str) -> bool:
-    """If ``output_file`` is a domain-path hit list, write that domain's neighborhood.
-
-    Returns True when the caller should skip normal extraction.
-    """
-    name = output_file.replace("\\", "/")
-    for suffix, hits in DOMAIN_SEARCH_HITS.items():
-        token = f"__{suffix}."
-        if token in name or name.endswith(f"__{suffix}"):
-            from pathlib import Path
-
-            path = Path(output_file)
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text("".join(hit + "\n" for hit in hits))
-            return True
-    return False
-
-
 def mock_requests_session_request():
     """
     Mock the `request` method of `requests.Session` to return mock responses

--- a/ProteinCartography/tests/mocks.py
+++ b/ProteinCartography/tests/mocks.py
@@ -37,6 +37,34 @@ def mock_run_blast():
     patch.start()
 
 
+# Distinct domain-path neighborhoods used by the two-domain Snakemake test.
+# These accessions have AlphaFold artifacts. Protein-path mocks still return the
+# full actin hit list, so a parent-PDB search that only relabels outputs cannot
+# produce this partitioned union.
+DOMAIN_SEARCH_HITS = {
+    "d01": ["A0A286Q506"],
+    "d02": ["Q6QAQ1"],
+}
+
+
+def maybe_write_per_domain_hits(output_file: str) -> bool:
+    """If ``output_file`` is a domain-path hit list, write that domain's neighborhood.
+
+    Returns True when the caller should skip normal extraction.
+    """
+    name = output_file.replace("\\", "/")
+    for suffix, hits in DOMAIN_SEARCH_HITS.items():
+        token = f"__{suffix}."
+        if token in name or name.endswith(f"__{suffix}"):
+            from pathlib import Path
+
+            path = Path(output_file)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("".join(hit + "\n" for hit in hits))
+            return True
+    return False
+
+
 def mock_requests_session_request():
     """
     Mock the `request` method of `requests.Session` to return mock responses
@@ -106,6 +134,10 @@ def mock_response(method, url, **_):
     # Requests to the alphafold files API.
     elif url.startswith("https://alphafold.ebi.ac.uk/files"):
         return mock_alphafold_files_api_responses(url)
+
+    # TED domain summaries (query gate and domain-path hit assignment).
+    elif "ted.cathdb.info" in url:
+        return mock_ted_api_responses(url)
 
     else:
         raise ValueError(f"Unexpected url: {url}")
@@ -195,6 +227,51 @@ def mock_foldseek_api_responses(method, url):
     else:
         raise ValueError(f"Unexpected url: {url}")
 
+    return mock_response
+
+
+def mock_ted_api_responses(url):
+    """TED summary API. Default: one domain (gate off). P99999: two domains (gate on)."""
+    mock_response = mock.Mock(spec=requests.Response)
+    accession = url.rstrip("/").split("/")[-1].split("?")[0]
+    if accession == "P99999":
+        mock_response.status_code = 200
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "ted_id": "AF-P99999-F1-model_v4_TED01",
+                    "uniprot_acc": "P99999",
+                    "chopping": "1-80",
+                    "nres_domain": 80,
+                    "cath_label": "3.40.50.300",
+                },
+                {
+                    "ted_id": "AF-P99999-F1-model_v4_TED02",
+                    "uniprot_acc": "P99999",
+                    "chopping": "81-160",
+                    "nres_domain": 80,
+                    "cath_label": "1.10.10.10",
+                },
+            ],
+            "count": 2,
+        }
+        return mock_response
+
+    mock_response.status_code = 200
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "ted_id": f"AF-{accession}-F1-model_v4_TED01",
+                "uniprot_acc": accession,
+                "chopping": "1-100",
+                "nres_domain": 100,
+                "cath_label": "1.10.10.10",
+            }
+        ],
+        "count": 1,
+    }
     return mock_response
 
 

--- a/ProteinCartography/tests/test_aggregate_domain_hits.py
+++ b/ProteinCartography/tests/test_aggregate_domain_hits.py
@@ -1,0 +1,83 @@
+"""Search-correctness: domain-path hit union is per-query-domain, not full-length search."""
+
+from __future__ import annotations
+from pathlib import Path
+
+import aggregate_domain_hits
+import domain_utils as du
+
+
+def test_union_of_per_domain_hits_includes_both_neighborhoods(tmp_path: Path):
+    d01 = tmp_path / "P99999__d01.foldseek_hits.txt"
+    d02 = tmp_path / "P99999__d02.foldseek_hits.txt"
+    d01.write_text("A1\n")
+    d02.write_text("B1\n")
+    out = tmp_path / "aggregated_hits.txt"
+    found = tmp_path / "found_by.tsv"
+    accessions = aggregate_domain_hits.aggregate_domain_hits(
+        [str(d01), str(d02)], str(out), str(found)
+    )
+    assert accessions == ["A1", "B1"]
+    text = found.read_text()
+    assert "A1\tP99999__d01" in text
+    assert "B1\tP99999__d02" in text
+
+
+def test_protein_path_hits_are_a_separate_list(tmp_path: Path):
+    """Full-length search of Q returning only A1 must not be used as the domain union."""
+    protein_hits = {"A1"}
+    d01 = tmp_path / "P99999__d01.blast_hits.uniprot.txt"
+    d02 = tmp_path / "P99999__d02.blast_hits.uniprot.txt"
+    d01.write_text("A1\n")
+    d02.write_text("B1\n")
+    domain_hits = set(
+        aggregate_domain_hits.aggregate_domain_hits(
+            [str(d01), str(d02)],
+            str(tmp_path / "agg.txt"),
+            str(tmp_path / "found.tsv"),
+        )
+    )
+    assert protein_hits == {"A1"}
+    assert domain_hits == {"A1", "B1"}
+    assert "B1" not in protein_hits
+
+
+def test_domain_search_inputs_are_cropped_domain_files_not_parent(tmp_path: Path):
+    """Per-domain search must use Q__dNN files; searching Q.pdb then splitting would fail this."""
+    parent_fasta = tmp_path / "Q.fasta"
+    parent_fasta.write_text(">Q\n" + "A" * 80 + "C" * 80 + "\n")
+    d01 = tmp_path / "Q__d01.fasta"
+    d02 = tmp_path / "Q__d02.fasta"
+    du.crop_fasta_file(parent_fasta, "1-80", d01, "Q__d01")
+    du.crop_fasta_file(parent_fasta, "81-160", d02, "Q__d02")
+    _, seq01 = du.parse_fasta(d01.read_text())
+    _, seq02 = du.parse_fasta(d02.read_text())
+    _, parent_seq = du.parse_fasta(parent_fasta.read_text())
+    assert seq01 != parent_seq
+    assert seq02 != parent_seq
+    assert seq01 != seq02
+    assert d01.name == "Q__d01.fasta"
+    assert d02.name == "Q__d02.fasta"
+
+
+def test_domain_id_from_hit_filename():
+    assert (
+        aggregate_domain_hits._domain_id_from_hit_file("out/P99999__d01.blast_hits.uniprot.txt")
+        == "P99999__d01"
+    )
+    parent, index = du.parse_domain_id("P99999__d02")
+    assert parent == "P99999" and index == 2
+
+
+def test_maybe_write_per_domain_hits_partitions_neighborhoods(tmp_path: Path):
+    from tests import mocks
+
+    d01 = tmp_path / "P99999__d01.foldseek_hits.txt"
+    d02 = tmp_path / "P99999__d02.blast_hits.uniprot.txt"
+    parent = tmp_path / "P99999.foldseek_hits.txt"
+    assert mocks.maybe_write_per_domain_hits(str(d01))
+    assert d01.read_text() == "A0A286Q506\n"
+    assert mocks.maybe_write_per_domain_hits(str(d02))
+    assert d02.read_text() == "Q6QAQ1\n"
+    assert not mocks.maybe_write_per_domain_hits(str(parent))
+    assert not parent.exists()

--- a/ProteinCartography/tests/test_aggregate_domain_hits.py
+++ b/ProteinCartography/tests/test_aggregate_domain_hits.py
@@ -70,14 +70,14 @@ def test_domain_id_from_hit_filename():
 
 
 def test_maybe_write_per_domain_hits_partitions_neighborhoods(tmp_path: Path):
-    from tests import mocks
+    from tests.mock_domain_hits import maybe_write_per_domain_hits
 
     d01 = tmp_path / "P99999__d01.foldseek_hits.txt"
     d02 = tmp_path / "P99999__d02.blast_hits.uniprot.txt"
     parent = tmp_path / "P99999.foldseek_hits.txt"
-    assert mocks.maybe_write_per_domain_hits(str(d01))
+    assert maybe_write_per_domain_hits(str(d01))
     assert d01.read_text() == "A0A286Q506\n"
-    assert mocks.maybe_write_per_domain_hits(str(d02))
+    assert maybe_write_per_domain_hits(str(d02))
     assert d02.read_text() == "Q6QAQ1\n"
-    assert not mocks.maybe_write_per_domain_hits(str(parent))
+    assert not maybe_write_per_domain_hits(str(parent))
     assert not parent.exists()

--- a/ProteinCartography/tests/test_assign_domains.py
+++ b/ProteinCartography/tests/test_assign_domains.py
@@ -1,0 +1,398 @@
+"""TED gate, user TSV precedence, cache, and omit-on-miss behavior."""
+
+from __future__ import annotations
+from pathlib import Path
+
+import assign_domains
+import domain_utils as du
+import pytest
+
+P00698_PAYLOAD = {
+    "data": [
+        {
+            "ted_id": "AF-P00698-F1-model_v4_TED01",
+            "uniprot_acc": "P00698",
+            "chopping": "22-141",
+            "nres_domain": 120,
+            "cath_label": "1.10.530.10",
+        }
+    ],
+    "count": 1,
+}
+
+TWO_DOMAIN_PAYLOAD = {
+    "data": [
+        {
+            "ted_id": "AF-P99999-F1-model_v4_TED01",
+            "uniprot_acc": "P99999",
+            "chopping": "1-80",
+            "nres_domain": 80,
+            "cath_label": "3.40.50.300",
+        },
+        {
+            "ted_id": "AF-P99999-F1-model_v4_TED02",
+            "uniprot_acc": "P99999",
+            "chopping": "81-160",
+            "nres_domain": 80,
+            "cath_label": "1.10.10.10",
+        },
+    ],
+    "count": 2,
+}
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 400
+        self._payload = payload if payload is not None else {"data": [], "count": 0}
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(
+        self, responses: dict[str, FakeResponse], errors: dict[str, Exception] | None = None
+    ):
+        self.responses = responses
+        self.errors = errors or {}
+        self.urls: list[str] = []
+        self._hits: dict[str, int] = {}
+
+    def get(self, url, timeout=60):
+        self.urls.append(url)
+        for key, err in self.errors.items():
+            if key in url:
+                raise err
+        for key, response in self.responses.items():
+            if key in url:
+                if isinstance(response, list):
+                    idx = self._hits.get(key, 0)
+                    self._hits[key] = idx + 1
+                    return response[min(idx, len(response) - 1)]
+                return response
+        return FakeResponse(404)
+
+
+def _write_query_files(input_dir: Path, protid: str, nres: int):
+    seq = "A" * nres
+    (input_dir / f"{protid}.fasta").write_text(f">{protid}\n{seq}\n")
+    atoms = []
+    for i in range(1, nres + 1):
+        atoms.append(
+            f"ATOM  {i:5d}  CA  ALA A{i:4d}    "
+            f"{float(i):8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00           C  "
+        )
+    (input_dir / f"{protid}.pdb").write_text("\n".join(atoms) + "\nEND\n")
+
+
+def test_p00698_gate_off(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P00698", 147)
+    session = FakeSession({"P00698": FakeResponse(200, P00698_PAYLOAD)})
+    gate = assign_domains.run_query_gate(
+        ["P00698"], str(input_dir), str(tmp_path / "domain"), session=session
+    )
+    assert gate == "off"
+    assert (tmp_path / "domain" / "query_domain_ids.txt").read_text() == ""
+
+
+def test_two_domain_ted_gate_on(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P99999", 160)
+    session = FakeSession({"P99999": FakeResponse(200, TWO_DOMAIN_PAYLOAD)})
+    out = tmp_path / "domain"
+    gate = assign_domains.run_query_gate(["P99999"], str(input_dir), str(out), session=session)
+    assert gate == "on"
+    ids = (out / "query_domain_ids.txt").read_text().splitlines()
+    assert ids == ["P99999__d01", "P99999__d02"]
+    assert (out / "query_structures" / "P99999__d01.fasta").is_file()
+    assert (out / "query_structures" / "P99999__d02.pdb").is_file()
+    fasta = (out / "query_structures" / "P99999__d01.fasta").read_text()
+    assert fasta.startswith(">P99999__d01")
+    assert "P99999.pdb" not in fasta
+
+
+def test_user_tsv_wins_over_ted(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P99999", 160)
+    tsv = tmp_path / "user.tsv"
+    tsv.write_text("parent_protid\tchopping\nP99999\t1-50\nP99999\t51-160\n")
+    session = FakeSession({"P99999": FakeResponse(200, TWO_DOMAIN_PAYLOAD)})
+    out = tmp_path / "domain"
+    assign_domains.run_query_gate(
+        ["P99999"],
+        str(input_dir),
+        str(out),
+        user_domains_file=str(tsv),
+        session=session,
+    )
+    text = (out / "query_domains.tsv").read_text()
+    assert "user" in text
+    assert "1-50" in text
+    assert session.urls == []
+
+
+def test_user_tsv_start_end_columns(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P99999", 160)
+    tsv = tmp_path / "user.tsv"
+    tsv.write_text("parent_protid\tstart\tend\nP99999\t1\t50\nP99999\t51\t160\n")
+    session = FakeSession({"P99999": FakeResponse(200, TWO_DOMAIN_PAYLOAD)})
+    out = tmp_path / "domain"
+    gate = assign_domains.run_query_gate(
+        ["P99999"],
+        str(input_dir),
+        str(out),
+        user_domains_file=str(tsv),
+        session=session,
+    )
+    assert gate == "on"
+    text = (out / "query_domains.tsv").read_text()
+    assert "1-50" in text
+    assert "51-160" in text
+
+
+def test_mixed_queries_only_crop_multidomain(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P00698", 147)
+    _write_query_files(input_dir, "P99999", 160)
+    session = FakeSession(
+        {
+            "P00698": FakeResponse(200, P00698_PAYLOAD),
+            "P99999": FakeResponse(200, TWO_DOMAIN_PAYLOAD),
+        }
+    )
+    out = tmp_path / "domain"
+    gate = assign_domains.run_query_gate(
+        ["P00698", "P99999"], str(input_dir), str(out), session=session
+    )
+    assert gate == "on"
+    ids = (out / "query_domain_ids.txt").read_text().splitlines()
+    assert ids == ["P99999__d01", "P99999__d02"]
+    assert not (out / "query_structures" / "P00698__d01.fasta").exists()
+    assert (out / "query_structures" / "P99999__d01.fasta").is_file()
+
+
+def test_query_ted_404_does_not_raise(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P99999", 160)
+    session = FakeSession({"P99999": FakeResponse(404)})
+    gate = assign_domains.run_query_gate(
+        ["P99999"], str(input_dir), str(tmp_path / "domain"), session=session
+    )
+    assert gate == "off"
+
+
+def test_query_ted_500_does_not_raise(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P99999", 160)
+    session = FakeSession({"P99999": FakeResponse(500)})
+    gate = assign_domains.run_query_gate(
+        ["P99999"], str(input_dir), str(tmp_path / "domain"), session=session
+    )
+    assert gate == "off"
+
+
+def test_ted_cache_skips_second_get(tmp_path: Path):
+    cache = tmp_path / "cache"
+    session = FakeSession({"P00698": FakeResponse(200, P00698_PAYLOAD)})
+    first = assign_domains.fetch_ted_summary("P00698", session, cache)
+    assert first["data"][0]["chopping"] == "22-141"
+    assert len(session.urls) == 1
+    session.errors = {"P00698": RuntimeError("network down")}
+    second = assign_domains.fetch_ted_summary("P00698", session, cache)
+    assert second["data"][0]["chopping"] == "22-141"
+    assert len(session.urls) == 1
+
+
+def test_assign_hits_omits_ted_404(tmp_path: Path):
+    pdb_dir = tmp_path / "pdbs"
+    pdb_dir.mkdir()
+    atoms = [
+        (
+            f"ATOM  {i:5d}  CA  ALA A{i:4d}    "
+            f"{float(i):8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00           C  "
+        )
+        for i in range(1, 101)
+    ]
+    (pdb_dir / "P11111.pdb").write_text("\n".join(atoms) + "\nEND\n")
+    hits = tmp_path / "hits.txt"
+    hits.write_text("P11111\n")
+    session = FakeSession({"P11111": FakeResponse(404)})
+    rows = assign_domains.assign_and_crop_hits(
+        accessions_file=str(hits),
+        pdb_dir=str(pdb_dir),
+        output_dir=str(tmp_path / "domain_structures"),
+        output_tsv=str(tmp_path / "domain_features.tsv"),
+        cache_dir=str(tmp_path / "cache"),
+        session=session,
+    )
+    assert rows == []
+    assert not (tmp_path / "domain_structures" / "P11111__d01.pdb").exists()
+    tsv = (tmp_path / "domain_features.tsv").read_text()
+    assert "full_chain" not in tsv
+
+
+def test_assign_hits_crops_both_domains_and_matches_ca_count(tmp_path: Path):
+    pdb_dir = tmp_path / "pdbs"
+    pdb_dir.mkdir()
+    _write_query_files(pdb_dir, "P99999", 160)
+    hits = tmp_path / "hits.txt"
+    hits.write_text("P99999\n")
+    session = FakeSession({"P99999": FakeResponse(200, TWO_DOMAIN_PAYLOAD)})
+    out_dir = tmp_path / "domain_structures"
+    rows = assign_domains.assign_and_crop_hits(
+        accessions_file=str(hits),
+        pdb_dir=str(pdb_dir),
+        output_dir=str(out_dir),
+        output_tsv=str(tmp_path / "domain_features.tsv"),
+        cache_dir=str(tmp_path / "cache"),
+        session=session,
+    )
+    assert {row["protid"] for row in rows} == {"P99999__d01", "P99999__d02"}
+    assert "full_chain" not in {row["assignment_source"] for row in rows}
+    for row in rows:
+        pdb_text = (out_dir / f"{row['protid']}.pdb").read_text()
+        resseqs = [int(line[22:26]) for line in pdb_text.splitlines() if line.startswith("ATOM")]
+        start, end = int(row["start"]), int(row["end"])
+        assert resseqs
+        assert min(resseqs) >= start
+        assert max(resseqs) <= end
+        assert int(row["nres_domain"]) == len(resseqs)
+
+
+def test_domain_map_off_skips_ted(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_query_files(input_dir, "P99999", 160)
+    session = FakeSession({"P99999": FakeResponse(200, TWO_DOMAIN_PAYLOAD)})
+    gate = assign_domains.run_query_gate(
+        ["P99999"],
+        str(input_dir),
+        str(tmp_path / "domain"),
+        domain_map="off",
+        session=session,
+    )
+    assert gate == "off"
+    assert session.urls == []
+
+
+def test_assign_hits_skips_query_parents_already_on_the_map(tmp_path: Path):
+    pdb_dir = tmp_path / "pdbs"
+    pdb_dir.mkdir()
+    _write_query_files(pdb_dir, "P99999", 160)
+    query_tsv = tmp_path / "query_domains.tsv"
+    assign_domains._write_domains_tsv(
+        query_tsv,
+        [
+            du.domain_row("P99999", 1, "1-80", "ted"),
+            du.domain_row("P99999", 2, "81-160", "ted"),
+        ],
+    )
+    query_structs = tmp_path / "query_structures"
+    query_structs.mkdir()
+    (query_structs / "P99999__d01.pdb").write_text((pdb_dir / "P99999.pdb").read_text())
+    (query_structs / "P99999__d02.pdb").write_text((pdb_dir / "P99999.pdb").read_text())
+    hits = tmp_path / "hits.txt"
+    hits.write_text("P99999\n")
+    session = FakeSession({"P99999": FakeResponse(200, TWO_DOMAIN_PAYLOAD)})
+    rows = assign_domains.assign_and_crop_hits(
+        accessions_file=str(hits),
+        pdb_dir=str(pdb_dir),
+        output_dir=str(tmp_path / "domain_structures"),
+        output_tsv=str(tmp_path / "domain_features.tsv"),
+        cache_dir=str(tmp_path / "cache"),
+        query_domains_tsv=str(query_tsv),
+        query_structures_dir=str(query_structs),
+        session=session,
+    )
+    protids = [row["protid"] for row in rows]
+    assert protids == ["P99999__d01", "P99999__d02"]
+    assert session.urls == []
+
+
+def test_assign_hits_drops_empty_crop(tmp_path: Path):
+    pdb_dir = tmp_path / "pdbs"
+    pdb_dir.mkdir()
+    atoms = [
+        (
+            f"ATOM  {i:5d}  CA  ALA A{i:4d}    "
+            f"{float(i):8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00           C  "
+        )
+        for i in range(200, 221)
+    ]
+    (pdb_dir / "P11111.pdb").write_text("\n".join(atoms) + "\nEND\n")
+    hits = tmp_path / "hits.txt"
+    hits.write_text("P11111\n")
+    payload = {
+        "data": [
+            {
+                "ted_id": "AF-P11111-F1-model_v4_TED01",
+                "uniprot_acc": "P11111",
+                "chopping": "1-80",
+                "nres_domain": 80,
+                "cath_label": "1.10.10.10",
+            }
+        ],
+        "count": 1,
+    }
+    session = FakeSession({"P11111": FakeResponse(200, payload)})
+    rows = assign_domains.assign_and_crop_hits(
+        accessions_file=str(hits),
+        pdb_dir=str(pdb_dir),
+        output_dir=str(tmp_path / "domain_structures"),
+        output_tsv=str(tmp_path / "domain_features.tsv"),
+        cache_dir=str(tmp_path / "cache"),
+        session=session,
+    )
+    assert rows == []
+    assert not (tmp_path / "domain_structures" / "P11111__d01.pdb").exists()
+
+
+def test_ted_429_retries_then_succeeds(tmp_path: Path):
+    session = FakeSession(
+        {
+            "P00698": [
+                FakeResponse(429),
+                FakeResponse(200, P00698_PAYLOAD),
+            ]
+        }
+    )
+    payload = assign_domains.fetch_ted_summary("P00698", session, tmp_path / "cache")
+    assert payload["data"][0]["chopping"] == "22-141"
+    assert len(session.urls) == 2
+
+
+def test_ted_paginates_until_short_page(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(du, "TED_PAGE_SIZE", 1)
+    page1 = {"data": [TWO_DOMAIN_PAYLOAD["data"][0]], "count": 1}
+    page2 = {"data": [TWO_DOMAIN_PAYLOAD["data"][1]], "count": 1}
+    page3 = {"data": [], "count": 0}
+
+    class PagingSession:
+        def __init__(self):
+            self.urls: list[str] = []
+
+        def get(self, url, timeout=60):
+            self.urls.append(url)
+            if "skip=2" in url:
+                return FakeResponse(200, page3)
+            if "skip=1" in url:
+                return FakeResponse(200, page2)
+            return FakeResponse(200, page1)
+
+    session = PagingSession()
+    payload = assign_domains.fetch_ted_summary("P99999", session, tmp_path / "cache")
+    assert len(payload["data"]) == 2
+    assert payload["data"][0]["chopping"] == "1-80"
+    assert payload["data"][1]["chopping"] == "81-160"
+    assert len(session.urls) == 3

--- a/ProteinCartography/tests/test_domain_utils.py
+++ b/ProteinCartography/tests/test_domain_utils.py
@@ -1,0 +1,144 @@
+"""Unit tests for domain identity, chopping, FASTA/PDB crop, and the multi-domain gate."""
+
+from __future__ import annotations
+import pathlib
+
+import config_utils
+import domain_utils as du
+import pytest
+
+P00698_CHOPPING = "22-141"
+
+
+def _ca_atom(serial: int, resseq: int, x: float = 0.0) -> str:
+    return (
+        f"ATOM  {serial:5d}  CA  ALA A{resseq:4d}    "
+        f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00           C  "
+    )
+
+
+def _pdb_for_residues(resseqs: list[int]) -> str:
+    lines = [_ca_atom(i + 1, resseq, float(i)) for i, resseq in enumerate(resseqs)]
+    lines.append("END")
+    return "\n".join(lines) + "\n"
+
+
+def test_parse_chopping_continuous():
+    assert du.parse_chopping("22-141") == [(22, 141)]
+
+
+def test_parse_chopping_discontinuous():
+    assert du.parse_chopping("22-50_80-120") == [(22, 50), (80, 120)]
+
+
+def test_parse_chopping_rejects_garbage():
+    with pytest.raises(du.DomainChoppingError):
+        du.parse_chopping("")
+    with pytest.raises(du.DomainChoppingError):
+        du.parse_chopping("abc")
+    with pytest.raises(du.DomainChoppingError):
+        du.parse_chopping("10-5")
+
+
+def test_domain_id_round_trip():
+    assert du.make_domain_id("P12345", 1) == "P12345__d01"
+    assert du.parse_domain_id("P12345__d01") == ("P12345", 1)
+    assert du.make_domain_id("P12345", 10) == "P12345__d10"
+    assert du.parse_domain_id("P12345__d10") == ("P12345", 10)
+
+
+def test_slice_fasta_one_based_inclusive():
+    sequence = "A" * 141
+    sliced = du.slice_fasta_sequence(sequence, P00698_CHOPPING)
+    assert sliced == sequence[21:141]
+    assert len(sliced) == 120
+
+
+def test_write_fasta_uses_domain_id_header(tmp_path: pathlib.Path):
+    out = tmp_path / "P00698__d01.fasta"
+    du.write_fasta(out, "P00698__d01", "ACDE")
+    header, seq = du.parse_fasta(out.read_text())
+    assert header == "P00698__d01"
+    assert seq == "ACDE"
+
+
+def test_crop_pdb_by_resseq_not_atom_serial():
+    pdb = _pdb_for_residues(list(range(1, 201)))
+    cropped, n_ca = du.crop_pdb_text(pdb, P00698_CHOPPING)
+    resseqs = []
+    for line in cropped.splitlines():
+        if line.startswith("ATOM"):
+            resseqs.append(int(line[22:26]))
+    assert min(resseqs) == 22
+    assert max(resseqs) == 141
+    assert n_ca == 120
+
+
+def test_crop_pdb_discontinuous_omits_gap():
+    pdb = _pdb_for_residues(list(range(1, 121)))
+    cropped, n_ca = du.crop_pdb_text(pdb, "22-50_80-120")
+    resseqs = {int(line[22:26]) for line in cropped.splitlines() if line.startswith("ATOM")}
+    assert 51 not in resseqs
+    assert 79 not in resseqs
+    assert 22 in resseqs and 50 in resseqs
+    assert 80 in resseqs and 120 in resseqs
+    assert n_ca == (50 - 22 + 1) + (120 - 80 + 1)
+
+
+def test_crop_pdb_uses_resseq_when_file_starts_at_20():
+    pdb = _pdb_for_residues(list(range(20, 50)))
+    cropped, n_ca = du.crop_pdb_text(pdb, "22-30")
+    resseqs = [int(line[22:26]) for line in cropped.splitlines() if line.startswith("ATOM")]
+    assert resseqs == list(range(22, 31))
+    assert n_ca == 9
+
+
+def test_min_domain_length_drops_short_span():
+    row = du.domain_row("P1", 1, "1-10", "ted", nres_domain=10)
+    kept = du.filter_domain_rows([row], min_domain_length=30)
+    assert kept == []
+
+
+def test_is_multidomain_gate():
+    two = [
+        du.domain_row("P1", 1, "1-80", "ted"),
+        du.domain_row("P1", 2, "81-160", "ted"),
+    ]
+    assert du.is_multidomain(len(du.filter_domain_rows(two, 30)))
+    one = [du.domain_row("P1", 1, "22-141", "ted")]
+    assert not du.is_multidomain(len(du.filter_domain_rows(one, 30)))
+    mixed = [
+        du.domain_row("P1", 1, "1-80", "ted"),
+        du.domain_row("P1", 2, "81-90", "ted", nres_domain=10),
+    ]
+    kept = du.filter_domain_rows(mixed, 30)
+    assert not du.is_multidomain(len(kept))
+    assert kept[0]["protid"] == "P1__d01"
+
+
+def test_looks_like_uniprot():
+    assert du.looks_like_uniprot_accession("P60709")
+    assert du.looks_like_uniprot_accession("P99999")
+    assert du.looks_like_uniprot_accession("A0A2Y9FRR4")
+    assert not du.looks_like_uniprot_accession("QTEST")
+
+
+def test_discontinuous_chopping_is_one_domain_instance():
+    row = du.domain_row("P12345", 1, "22-50_80-120", "ted")
+    assert row["protid"] == "P12345__d01"
+    assert row["chopping"] == "22-50_80-120"
+    assert row["nres_domain"] == (50 - 22 + 1) + (120 - 80 + 1)
+
+
+def test_domain_map_config_values():
+    assert config_utils._get_domain_map({}) == "auto"
+    assert config_utils._get_domain_map({"domain_map": "OFF"}) == "off"
+    with pytest.raises(config_utils.ProteinCartographyInputError):
+        config_utils._get_domain_map({"domain_map": "domain-only"})
+
+
+def test_missing_user_domains_file_raises(tmp_path: pathlib.Path):
+    with pytest.raises(config_utils.ProteinCartographyInputError, match="user_domains_file"):
+        config_utils._get_user_domains_file(
+            {"input_dir": str(tmp_path), "user_domains_file": "missing.tsv"}
+        )

--- a/ProteinCartography/tests/test_join_domain_features.py
+++ b/ProteinCartography/tests/test_join_domain_features.py
@@ -1,0 +1,28 @@
+"""Join UniProt columns onto domain rows without replacing domain ids."""
+
+from __future__ import annotations
+from pathlib import Path
+
+import join_domain_features
+
+
+def test_join_keeps_domain_id_and_copies_parent_metadata(tmp_path: Path):
+    domain = tmp_path / "domains.tsv"
+    domain.write_text(
+        "protid\tparent_protid\tchopping\tcath_label\tnres_domain\n"
+        "P12345__d01\tP12345\t1-80\t3.40.50.300\t80\n"
+    )
+    uniprot = tmp_path / "uniprot.tsv"
+    uniprot.write_text(
+        "protid\tProtein names\tOrganism\tLength\nP12345\tExample protein\tHomo sapiens\t375\n"
+    )
+    found = tmp_path / "found.tsv"
+    found.write_text("accession\tfound_by\nP12345\tP99999__d01\n")
+    out = tmp_path / "joined.tsv"
+    df = join_domain_features.join_domain_uniprot(
+        str(domain), str(uniprot), str(out), found_by_file=str(found)
+    )
+    assert list(df["protid"]) == ["P12345__d01"]
+    assert df.loc[0, "Protein names"] == "Example protein"
+    assert df.loc[0, "found_by"] == "P99999__d01"
+    assert int(df.loc[0, "Length"]) == 80

--- a/ProteinCartography/tests/test_live_ted.py
+++ b/ProteinCartography/tests/test_live_ted.py
@@ -1,0 +1,17 @@
+"""Live TED schema check. Not run in default CI: pytest -m live_ted."""
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+TED_URL = "https://ted.cathdb.info/api/v1/uniprot/summary/P00698"
+
+
+@pytest.mark.live_ted
+def test_p00698_chopping_is_still_22_141():
+    response = requests.get(TED_URL, timeout=60)
+    response.raise_for_status()
+    payload = response.json()
+    choppings = [item["chopping"] for item in payload.get("data") or []]
+    assert "22-141" in choppings

--- a/ProteinCartography/tests/test_pipeline_in_cluster_mode.py
+++ b/ProteinCartography/tests/test_pipeline_in_cluster_mode.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import shutil
 
@@ -45,7 +46,18 @@ def stage_inputs(integration_test_artifacts_dirpath, config_filepath):
     )
 
 
+@pytest.fixture
+def set_env_variables(pytestconfig):
+    """Mock TED (and other HTTP) so domain_map auto does not call live APIs."""
+    should_use_mocks = "PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS"
+    if not pytestconfig.getoption("no_mocks"):
+        os.environ[should_use_mocks] = "true"
+    yield
+    os.environ.pop(should_use_mocks, None)
+
+
 @pytest.mark.usefixtures("stage_inputs")
+@pytest.mark.usefixtures("set_env_variables")
 def test_pipeline_in_cluster_mode(repo_dirpath, config_filepath):
     """
     Run the pipeline in "cluster" mode with the test config file.
@@ -87,3 +99,8 @@ def test_pipeline_in_cluster_mode(repo_dirpath, config_filepath):
 
     # The matrix should have one row and one column per structure (plus one column for the index).
     assert similarity_matrix.shape == (num_structures, num_structures + 1)
+
+    # Actin cluster inputs are single-domain under the TED mock; the domain DAG is a no-op.
+    domain_html_name = f"{config['analysis_name']}_leiden_similarity_domain.html"
+    domain_html = output_dirpath / "final_results" / domain_html_name
+    assert not domain_html.exists()

--- a/ProteinCartography/tests/test_pipeline_in_search_mode.py
+++ b/ProteinCartography/tests/test_pipeline_in_search_mode.py
@@ -127,3 +127,9 @@ def test_pipeline_in_search_mode_with_mocked_api_calls(repo_dirpath, config_file
     )
     similarity_matrix = pd.read_csv(similarity_matrix_filepath, sep="\t")
     assert similarity_matrix.shape == (11, 12)
+
+    domain_html_name = f"{config['analysis_name']}_leiden_similarity_domain.html"
+    domain_html = output_dirpath / "final_results" / domain_html_name
+    assert not domain_html.exists()
+    domain_structs = output_dirpath / "domain_path" / "domain_structures"
+    assert not domain_structs.exists() or not any(domain_structs.glob("*.pdb"))

--- a/ProteinCartography/tests/test_pipeline_in_search_mode_domain.py
+++ b/ProteinCartography/tests/test_pipeline_in_search_mode_domain.py
@@ -1,0 +1,126 @@
+"""Mocked Snakemake run of the parallel domain path for a two-domain query."""
+
+from __future__ import annotations
+import os
+import pathlib
+
+import pandas as pd
+import pytest
+import snakemake
+import yaml
+
+
+def _ca_pdb(nres: int) -> str:
+    lines = [
+        f"ATOM  {i:5d}  CA  ALA A{i:4d}    "
+        f"{float(i):8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00           C  "
+        for i in range(1, nres + 1)
+    ]
+    return "\n".join(lines) + "\nEND\n"
+
+
+def _load_config(filepath):
+    with open(filepath) as file:
+        return yaml.safe_load(file)
+
+
+@pytest.fixture
+def config_filepath(tmp_path):
+    config = {
+        "mode": "search",
+        "analysis_name": "testdomain",
+        "input_dir": str(tmp_path / "input"),
+        "output_dir": str(tmp_path / "output"),
+        "plotting_modes": ["pca_umap"],
+        "max_blast_hits": 10,
+        "max_foldseek_hits": 10,
+        "max_structures": 10,
+        "domain_map": "auto",
+    }
+    filepath = tmp_path / "config.yaml"
+    with open(filepath, "w") as file:
+        yaml.dump(config, file)
+    return str(filepath)
+
+
+@pytest.fixture
+def stage_inputs(config_filepath):
+    config = _load_config(config_filepath)
+    input_dir = pathlib.Path(config["input_dir"])
+    input_dir.mkdir(parents=True)
+    (input_dir / "P99999.fasta").write_text(">P99999\n" + "A" * 160 + "\n")
+    (input_dir / "P99999.pdb").write_text(_ca_pdb(160))
+
+
+@pytest.fixture
+def set_env_variables(pytestconfig):
+    should_use_mocks = "PROTEINCARTOGRAPHY_SHOULD_USE_MOCKS"
+    should_log_api_requests = "PROTEINCARTOGRAPHY_SHOULD_LOG_API_REQUESTS"
+    if not pytestconfig.getoption("no_mocks"):
+        os.environ[should_use_mocks] = "true"
+    should_log_api_requests_value = os.environ.pop(should_log_api_requests, None)
+    yield
+    os.environ.pop(should_use_mocks, None)
+    if should_log_api_requests_value is not None:
+        os.environ[should_log_api_requests] = should_log_api_requests_value
+
+
+@pytest.mark.usefixtures("stage_inputs")
+@pytest.mark.usefixtures("set_env_variables")
+def test_pipeline_in_search_mode_domain_map(repo_dirpath, config_filepath):
+    snakemake.snakemake(
+        snakefile=(repo_dirpath / "Snakefile"),
+        configfiles=[config_filepath],
+        use_conda=True,
+        cores=8,
+        verbose=True,
+    )
+
+    config = _load_config(config_filepath)
+    output_dirpath = pathlib.Path(config["output_dir"])
+    name = config["analysis_name"]
+
+    protein_html = output_dirpath / "final_results" / f"{name}_leiden_similarity.html"
+    domain_html = output_dirpath / "final_results" / f"{name}_leiden_similarity_domain.html"
+    assert protein_html.exists()
+    assert domain_html.exists()
+
+    domain_matrix = (
+        output_dirpath / "foldseek_clustering_results_domain" / "all_by_all_tmscore_pivoted.tsv"
+    )
+    assert domain_matrix.exists()
+    df = pd.read_csv(domain_matrix, sep="\t")
+    assert "protid" in df.columns
+    assert df["protid"].astype(str).str.contains("__d").all()
+    assert "P99999__d01" in set(df["protid"].astype(str))
+    assert "P99999__d02" in set(df["protid"].astype(str))
+
+    features = pd.read_csv(
+        output_dirpath / "final_results" / f"{name}_aggregated_features_domain.tsv", sep="\t"
+    )
+    tm_cols = [c for c in features.columns if c.startswith("TMscore_v_")]
+    assert tm_cols
+    assert all(c.replace("TMscore_v_", "").startswith("P99999__d") for c in tm_cols)
+    assert "TMscore_v_P99999" not in tm_cols
+    assert not any(c.startswith("fident_v_") for c in features.columns)
+
+    query_fastas = list(
+        (output_dirpath / "domain_path" / "query_structures").glob("P99999__d*.fasta")
+    )
+    assert {p.name for p in query_fastas} == {"P99999__d01.fasta", "P99999__d02.fasta"}
+
+    domain_hits = {
+        line
+        for line in (output_dirpath / "domain_path" / "features" / "aggregated_hits.txt")
+        .read_text()
+        .splitlines()
+        if line
+    }
+    assert domain_hits == {"A0A286Q506", "Q6QAQ1"}
+    found = (output_dirpath / "domain_path" / "features" / "found_by.tsv").read_text()
+    assert "A0A286Q506\tP99999__d01" in found
+    assert "Q6QAQ1\tP99999__d02" in found
+    protein_hits_file = output_dirpath / "protein_features" / "aggregated_hits.txt"
+    if protein_hits_file.is_file():
+        protein_hits = {line for line in protein_hits_file.read_text().splitlines() if line}
+        assert domain_hits != protein_hits

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Comparing protein structures across organisms can help us generate interesting b
 
 Our pipeline starts with user-provided protein(s) of interest and searches the available sequence and structure databases for matches. Using the full list of matches, we can build a "map" of all the similar proteins and look for clusters of proteins with similar features. Overlaying a variety of different parameters such as taxonomy, sequence divergence, and other features onto these spaces allows us to explore the features that drive differences between clusters.
 
-Because this tool is based on global structural comparisons, note that the results are not always useful for long proteins (>1200 amino acids), multi-domain proteins, or proteins with large unstructured regions. Additionally, while we find that the results for average length, well-structured proteins appear generally as expected, we have not yet comprehensively validated the clustering parameters, so users may find that different parameters work better for their specific analyses.
+Because this tool is based on global structural comparisons, note that the results are not always useful for long proteins (>1200 amino acids), multi-domain proteins, or proteins with large unstructured regions. For multi-domain queries, the pipeline can also run a **parallel domain map** (see [Domain maps](#domain-maps)). Additionally, while we find that the results for average length, well-structured proteins appear generally as expected, we have not yet comprehensively validated the clustering parameters, so users may find that different parameters work better for their specific analyses.
 
 ## Quickstart
 
@@ -166,6 +166,18 @@ In this mode, the pipeline starts with a folder containing PDBs of interest and 
 ```
 snakemake --configfile config.yml --use-conda --cores n
 ```
+
+### Domain maps
+
+The protein search and map always run as described above. If a **query** protein has two or more structural domains, the pipeline also runs a **parallel domain path** that does not change protein-path inputs, directories, or filenames.
+
+- **Gate:** [TED](https://ted.cathdb.info/) (The Encyclopedia of Domains) is queried for each input UniProt accession, or you can supply `user_domains_file` (a TSV with `parent_protid` and `chopping`, or `start`/`end`). Spans shorter than `min_domain_length` (default 30) are ignored. The domain path starts only when at least one query has two or more kept domains.
+- **Single-domain queries:** the domain path does not run. There is no extra BLAST/Foldseek, no `*_domain.html`, and the protein map is unchanged. Set `domain_map: off` to force this skip even for multi-domain queries.
+- **When gated on:** each query domain is cropped (`{accession}__d01`, …) and searched with BLAST and Foldseek independently. Hits are unioned, downloaded, and TED-cropped. Clustering uses the same Foldseek/Leiden/plot scripts on those domain PDBs.
+- **Outputs:** `{analysis_name}_*_domain.html` / `.tsv` / `.pdf` in `final_results/`, plus `domain_path/` and `foldseek_clustering_results_domain/`. Protein `final_results` names are unchanged.
+- TED HTTP failures on a query are treated as “not multi-domain” and do not fail the protein pipeline. Hit accessions with no TED assignment are omitted from the domain map only.
+
+TED: Lau et al., Science 386, eadq4946 (2024). https://doi.org/10.1126/science.adq4946
 
 ## Directory Structure
 
@@ -435,6 +447,9 @@ For either custom proteins provided through `override_file` in either mode, or b
 | feature | example | description | source |
 |--------:|:-------:|:------------|:-------|
 |`"protid"` | `"P42212"` | *(Required)* the unique identifier of the protein. Usually the UniProt accession, but can be any alphanumeric string | User-provided or UniProt |
+|`"parent_protid"` | `"P42212"` | *(Hovertext, domain map)* parent protein of a domain instance (`P42212__d01`) | TED / user TSV |
+|`"chopping"` | `"22-141"` | *(Hovertext, domain map)* 1-based residue span(s); discontinuous domains use `_` | TED / user TSV |
+|`"cath_label"` | `"1.10.530.10"` | *(Plotting, domain map)* CATH assignment from TED | TED |
 |`"Protein names"`| `"Green fluorescent protein"` | *(Hovertext)* a human-readable description of the protein | UniProt |
 |`"Gene Names (primary)"` | `"GFP"` | *(Hovertext)* a gene symbol for the protein | UniProt |
 |`"Annotation"`| `5` | *(Plotting)* UniProt [Annotation Score](https://www.uniprot.org/help/annotation_score) (0 to 5) | UniProt |

--- a/Snakefile
+++ b/Snakefile
@@ -81,6 +81,24 @@ MIN_LENGTH = int(config["min_length"])
 MAX_LENGTH = int(config["max_length"])
 UNIPROT_ADDITIONAL_FIELDS = config["uniprot_additional_fields"]
 
+# Parallel domain map (gated). Protein-path directories and rules above are unchanged.
+DOMAIN_MAP = config_utils._get_domain_map(config)
+MIN_DOMAIN_LENGTH = config_utils._get_min_domain_length(config)
+USER_DOMAINS_FILE = config_utils._get_user_domains_file(config)
+DOMAIN_DIR = OUTPUT_DIR / "domain_path"
+DOMAIN_BLAST_DIR = DOMAIN_DIR / "blast_results"
+DOMAIN_FOLDSEEK_DIR = DOMAIN_DIR / "foldseek_results"
+DOMAIN_HIT_STRUCTURES_DIR = DOMAIN_DIR / "hit_structures"
+DOMAIN_STRUCTURES_DIR = DOMAIN_DIR / "domain_structures"
+DOMAIN_CLUSTERING_DIR = OUTPUT_DIR / "foldseek_clustering_results_domain"
+DOMAIN_TMSCORES_DIR = OUTPUT_DIR / "key_domain_tmscores_results"
+DOMAIN_FEATURES_DIR = DOMAIN_DIR / "features"
+DOMAIN_GATE_PROTIDS = (
+    SEARCH_MODE_INPUT_PROTIDS
+    if MODE == config_utils.Mode.SEARCH
+    else [path.stem for path in sorted(INPUT_DIR.glob("*.pdb"))]
+)
+
 
 wildcard_constraints:
     plotting_mode="|".join(PLOTTING_MODES),
@@ -278,6 +296,8 @@ rule aggregate_hits:
         aggregated_hits=PROTEIN_FEATURES_DIR / "aggregated_hits.txt",
     benchmark:
         BENCHMARKS_DIR / "aggregate_hits.txt"
+    conda:
+        "envs/pandas.yml"
     shell:
         """
         python ProteinCartography/aggregate_hits.py --input {input} --output {output}
@@ -770,6 +790,9 @@ rule plot_cluster_distributions:
         """
 
 
+include: "Snakefile_domain"
+
+
 rule all:
     """
     This is a pseudo-rule that defines the final outputs of the pipeline
@@ -778,6 +801,7 @@ rule all:
     in order to allow the definition of its inputs in terms of the outputs of other rules
     (whose definitions must appear before this rule)
     """
+
     # we use `default_target` to tell snakemake that this is the first rule to run
     # (it otherwise defaults to running the first rule in the snakefile)
     default_target: True
@@ -788,3 +812,4 @@ rule all:
         rules.plot_semantic_analysis.output.pdf,
         expand(rules.plot_interactive.output.html, plotting_mode=PLOTTING_MODES),
         expand(rules.plot_cluster_distributions.output.svg, protid=KEY_PROTIDS),
+        domain_final_outputs,

--- a/Snakefile_domain
+++ b/Snakefile_domain
@@ -1,0 +1,550 @@
+# Parallel domain-map DAG. Included by the main Snakefile.
+# Protein-path rules are not redefined here. This DAG is requested only when
+# domain_final_outputs() sees the query-gate checkpoint flip to "on".
+
+
+wildcard_constraints:
+    domain_id=".+" + "__d" + "[0-9]+",
+
+
+def _domain_gate_pdb_inputs(_wildcards=None):
+    return expand(INPUT_DIR / "{protid}.pdb", protid=DOMAIN_GATE_PROTIDS)
+
+
+checkpoint domain_query_gate:
+    """TED/user TSV on query proteins. Writes gate.txt (on/off) and cropped query domains."""
+    input:
+        _domain_gate_pdb_inputs,
+    output:
+        gate=DOMAIN_DIR / "gate.txt",
+        query_ids=DOMAIN_DIR / "query_domain_ids.txt",
+        query_domains=DOMAIN_DIR / "query_domains.tsv",
+        query_structures=directory(DOMAIN_DIR / "query_structures"),
+    params:
+        protids=" ".join(DOMAIN_GATE_PROTIDS),
+        user_file=USER_DOMAINS_FILE,
+    conda:
+        "envs/web_apis.yml"
+    shell:
+        """
+        python ProteinCartography/assign_domains.py query-gate \
+            --protids {params.protids} \
+            --input-dir {INPUT_DIR} \
+            --output-dir {DOMAIN_DIR} \
+            --user-domains-file "{params.user_file}" \
+            --min-domain-length {MIN_DOMAIN_LENGTH} \
+            --domain-map {DOMAIN_MAP}
+        """
+
+
+def domain_gate_is_on(wildcards):
+    if DOMAIN_MAP == "off":
+        return False
+    if not DOMAIN_GATE_PROTIDS:
+        return False
+    gate_file = checkpoints.domain_query_gate.get(**wildcards).output.gate
+    return Path(gate_file).read_text().strip() == "on"
+
+
+def get_query_domain_ids(wildcards):
+    if not domain_gate_is_on(wildcards):
+        return []
+    ids_file = checkpoints.domain_query_gate.get(**wildcards).output.query_ids
+    return [line for line in Path(ids_file).read_text().splitlines() if line]
+
+
+def domain_final_outputs(wildcards):
+    if not domain_gate_is_on(wildcards):
+        return []
+    outputs = [
+        FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_leiden_similarity_domain.html",
+        FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_strucluster_similarity_domain.html",
+        FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_semantic_analysis_domain.html",
+        FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_semantic_analysis_domain.pdf",
+    ]
+    outputs += expand(
+        FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_aggregated_features_{plotting_mode}_domain.html"),
+        plotting_mode=PLOTTING_MODES,
+    )
+    outputs += expand(
+        FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_{domain_id}_distribution_analysis_domain.svg"),
+        domain_id=get_query_domain_ids(wildcards),
+    )
+    return outputs
+
+
+if MODE == config_utils.Mode.SEARCH:
+
+    rule domain_run_blast:
+        input:
+            fasta_file=DOMAIN_DIR / "query_structures" / "{domain_id}.fasta",
+        output:
+            blast_results=DOMAIN_BLAST_DIR / "{domain_id}.blast_results.tsv",
+        conda:
+            "envs/blast.yml"
+        shell:
+            """
+            python ProteinCartography/run_blast.py \
+              --query {input.fasta_file} \
+              --out {output.blast_results} \
+              --max_target_seqs {MAX_BLAST_HITS} \
+              --word_size {BLAST_WORD_SIZE} \
+              --word_size_backoff {BLAST_WORD_SIZE_BACKOFF} \
+              --num_attempts {BLAST_NUM_ATTEMPTS} \
+              --evalue {BLAST_EVALUE} \
+              --timeout_seconds {BLAST_TIMEOUT_SECONDS} \
+              --database {BLAST_DATABASE}
+            """
+
+    rule domain_extract_blast_hits:
+        input:
+            blast_results=rules.domain_run_blast.output.blast_results,
+        output:
+            blast_hits=DOMAIN_BLAST_DIR / "{domain_id}.blast_hits.refseq.txt",
+        conda:
+            "envs/pandas.yml"
+        shell:
+            """
+            python ProteinCartography/extract_blast_hits.py \
+                --input {input.blast_results} \
+                --output {output.blast_hits}
+            """
+
+    rule domain_map_refseq_ids:
+        input:
+            blast_hits=rules.domain_extract_blast_hits.output.blast_hits,
+        output:
+            blast_hits_uniprot_ids=DOMAIN_BLAST_DIR / "{domain_id}.blast_hits.uniprot.txt",
+        conda:
+            "envs/web_apis.yml"
+        shell:
+            """
+            python ProteinCartography/map_refseq_ids.py \
+                --input {input.blast_hits} \
+                --output {output.blast_hits_uniprot_ids}
+            """
+
+    rule domain_run_foldseek:
+        input:
+            pdb_file=DOMAIN_DIR / "query_structures" / "{domain_id}.pdb",
+        output:
+            foldseek_output=DOMAIN_FOLDSEEK_DIR / "{domain_id}.fsresults.tar.gz",
+            m8_files_dir=directory(DOMAIN_FOLDSEEK_DIR / "{domain_id}"),
+            m8_files=expand(
+                DOMAIN_FOLDSEEK_DIR / "{{domain_id}}" / "alis_{db}.m8",
+                db=FOLDSEEK_DATABASES,
+            ),
+        conda:
+            "envs/web_apis.yml"
+        shell:
+            """
+            python ProteinCartography/foldseek_apiquery.py \
+                --input {input.pdb_file} \
+                --output {output.foldseek_output} \
+                --server {FOLDSEEK_SERVER_URL} \
+                --database {FOLDSEEK_DATABASES}
+            tar -xvf {output.foldseek_output} -C {output.m8_files_dir}
+            """
+
+    rule domain_extract_foldseek_hits:
+        input:
+            m8_files=rules.domain_run_foldseek.output.m8_files,
+        output:
+            foldseek_hits=DOMAIN_FOLDSEEK_DIR / "{domain_id}.foldseek_hits.txt",
+        conda:
+            "envs/pandas.yml"
+        shell:
+            """
+            python ProteinCartography/extract_foldseek_hits.py \
+                --input {input.m8_files} \
+                --output {output.foldseek_hits} \
+                --max-num-hits {MAX_FOLDSEEK_HITS}
+            """
+
+    rule domain_aggregate_hits:
+        input:
+            lambda wildcards: expand(
+                rules.domain_map_refseq_ids.output.blast_hits_uniprot_ids,
+                domain_id=get_query_domain_ids(wildcards),
+            )
+            + expand(
+                rules.domain_extract_foldseek_hits.output.foldseek_hits,
+                domain_id=get_query_domain_ids(wildcards),
+            ),
+        output:
+            aggregated_hits=DOMAIN_FEATURES_DIR / "aggregated_hits.txt",
+            found_by=DOMAIN_FEATURES_DIR / "found_by.tsv",
+        conda:
+            "envs/pandas.yml"
+        shell:
+            """
+            python ProteinCartography/aggregate_domain_hits.py \
+                --input {input} \
+                --output {output.aggregated_hits} \
+                --found-by {output.found_by}
+            """
+
+    rule domain_fetch_uniprot_metadata:
+        input:
+            rules.domain_aggregate_hits.output.aggregated_hits,
+        output:
+            uniprot_features=DOMAIN_FEATURES_DIR / "uniprot_features.tsv",
+        conda:
+            "envs/web_apis.yml"
+        shell:
+            """
+            python ProteinCartography/fetch_uniprot_metadata.py \
+                --input {input} \
+                --output {output.uniprot_features} \
+                --additional-fields {UNIPROT_ADDITIONAL_FIELDS}
+            """
+
+    rule domain_filter_hits:
+        input:
+            rules.domain_fetch_uniprot_metadata.output.uniprot_features,
+        output:
+            filtered_hits=DOMAIN_FEATURES_DIR / "filtered_hits.txt",
+        conda:
+            "envs/pandas.yml"
+        shell:
+            """
+            python ProteinCartography/filter_aggregated_hits.py \
+                --input {input} \
+                --output {output.filtered_hits} \
+                --min-length 0 \
+                --max-length 0 \
+                --excluded-protids {DOMAIN_GATE_PROTIDS}
+            """
+
+    rule domain_download_pdbs:
+        input:
+            rules.domain_filter_hits.output.filtered_hits,
+        output:
+            hit_structures=directory(DOMAIN_HIT_STRUCTURES_DIR),
+        conda:
+            "envs/web_apis.yml"
+        shell:
+            """
+            python ProteinCartography/download_pdbs.py \
+                --input {input} \
+                --output {output.hit_structures} \
+                --max-structures {MAX_STRUCTURES}
+            """
+
+    checkpoint domain_prepare_structures:
+        input:
+            hits=rules.domain_filter_hits.output.filtered_hits,
+            hit_structures=rules.domain_download_pdbs.output.hit_structures,
+            query_domains=DOMAIN_DIR / "query_domains.tsv",
+            query_structures=DOMAIN_DIR / "query_structures",
+        output:
+            structures=directory(DOMAIN_STRUCTURES_DIR),
+            features=DOMAIN_FEATURES_DIR / "domain_features.tsv",
+        conda:
+            "envs/web_apis.yml"
+        shell:
+            """
+            python ProteinCartography/assign_domains.py assign-hits \
+                --accessions-file {input.hits} \
+                --pdb-dir {input.hit_structures} \
+                --output-dir {output.structures} \
+                --output-tsv {output.features} \
+                --cache-dir {DOMAIN_DIR}/ted_cache \
+                --min-domain-length {MIN_DOMAIN_LENGTH} \
+                --query-domains-tsv {input.query_domains} \
+                --query-structures-dir {input.query_structures} \
+                --user-domains-file "{USER_DOMAINS_FILE}"
+            """
+
+else:
+
+    rule domain_cluster_accessions:
+        input:
+            DOMAIN_DIR / "gate.txt",
+        output:
+            accessions=DOMAIN_FEATURES_DIR / "cluster_accessions.txt",
+            found_by=DOMAIN_FEATURES_DIR / "found_by.tsv",
+        shell:
+            """
+            mkdir -p {DOMAIN_FEATURES_DIR}
+            printf "%s\\n" {DOMAIN_GATE_PROTIDS} > {output.accessions}
+            printf "accession\\tfound_by\\n" > {output.found_by}
+            """
+
+    checkpoint domain_prepare_structures:
+        input:
+            accessions=rules.domain_cluster_accessions.output.accessions,
+            query_domains=DOMAIN_DIR / "query_domains.tsv",
+            query_structures=DOMAIN_DIR / "query_structures",
+        output:
+            structures=directory(DOMAIN_STRUCTURES_DIR),
+            features=DOMAIN_FEATURES_DIR / "domain_features.tsv",
+        conda:
+            "envs/web_apis.yml"
+        shell:
+            """
+            python ProteinCartography/assign_domains.py assign-hits \
+                --accessions-file {input.accessions} \
+                --pdb-dir {INPUT_DIR} \
+                --output-dir {output.structures} \
+                --output-tsv {output.features} \
+                --cache-dir {DOMAIN_DIR}/ted_cache \
+                --min-domain-length {MIN_DOMAIN_LENGTH} \
+                --query-domains-tsv {input.query_domains} \
+                --query-structures-dir {input.query_structures} \
+                --user-domains-file "{USER_DOMAINS_FILE}"
+            """
+
+
+def get_domain_pdb_filepaths(wildcards):
+    ckpt = checkpoints.domain_prepare_structures.get(**wildcards)
+    return sorted(Path(ckpt.output.structures).glob("*.pdb"))
+
+
+rule domain_assess_pdbs:
+    input:
+        get_domain_pdb_filepaths,
+    output:
+        pdb_features=DOMAIN_FEATURES_DIR / "pdb_features.tsv",
+    conda:
+        "envs/plotting.yml"
+    shell:
+        """
+        python ProteinCartography/assess_pdbs.py \
+            --input {DOMAIN_STRUCTURES_DIR} \
+            --output {output.pdb_features}
+        """
+
+
+rule domain_foldseek_clustering:
+    input:
+        get_domain_pdb_filepaths,
+    output:
+        all_by_all_tmscores=DOMAIN_CLUSTERING_DIR / "all_by_all_tmscore_pivoted.tsv",
+        struclusters_features=DOMAIN_CLUSTERING_DIR / "struclusters_features.tsv",
+        foldseek_database=DOMAIN_CLUSTERING_DIR / "temp" / "temp_db",
+    conda:
+        "envs/foldseek.yml"
+    resources:
+        mem_mb=32 * 1000,
+    threads: 16
+    shell:
+        """
+        python ProteinCartography/foldseek_clustering.py \
+            --query-folder {DOMAIN_STRUCTURES_DIR} \
+            --results-folder {DOMAIN_CLUSTERING_DIR}
+        """
+
+
+rule domain_copy_key_pdbs:
+    input:
+        get_domain_pdb_filepaths,
+    output:
+        dirpath=directory(DOMAIN_TMSCORES_DIR),
+    params:
+        domain_ids=lambda wildcards: " ".join(get_query_domain_ids(wildcards)),
+    shell:
+        """
+        mkdir -p "{output.dirpath}"
+        for domain_id in {params.domain_ids}; do
+        cp "{DOMAIN_STRUCTURES_DIR}/${{domain_id}}.pdb" "{output.dirpath}"
+        done
+        """
+
+
+rule domain_calculate_key_tmscores:
+    input:
+        pdb_dirpath=rules.domain_copy_key_pdbs.output.dirpath,
+        foldseek_database=rules.domain_foldseek_clustering.output.foldseek_database,
+    output:
+        key_tmscores=DOMAIN_FEATURES_DIR / "key_protid_tmscore_features.tsv",
+    conda:
+        "envs/foldseek.yml"
+    shell:
+        """
+        python ProteinCartography/calculate_key_protid_tmscores.py \
+            --query-database {input.foldseek_database} \
+            --target-folder {input.pdb_dirpath} \
+            --results-folder {input.pdb_dirpath} \
+            --features-file {output.key_tmscores}
+        """
+
+
+rule domain_dim_reduction:
+    input:
+        rules.domain_foldseek_clustering.output.all_by_all_tmscores,
+    output:
+        all_by_all_tmscores=DOMAIN_CLUSTERING_DIR / "all_by_all_tmscore_pivoted_{plotting_mode}.tsv",
+    conda:
+        "envs/analysis.yml"
+    shell:
+        """
+        python ProteinCartography/dim_reduction.py --input {input} --mode {wildcards.plotting_mode}
+        """
+
+
+rule domain_leiden_clustering:
+    input:
+        rules.domain_foldseek_clustering.output.all_by_all_tmscores,
+    output:
+        leiden_features=DOMAIN_CLUSTERING_DIR / "leiden_features.tsv",
+    conda:
+        "envs/analysis.yml"
+    shell:
+        """
+        python ProteinCartography/leiden_clustering.py \
+            --input {input} \
+            --output {output.leiden_features}
+        """
+
+
+def get_domain_uniprot_features(wildcards):
+    if MODE == config_utils.Mode.SEARCH:
+        return rules.domain_fetch_uniprot_metadata.output.uniprot_features
+    return FEATURES_FILE
+
+
+def get_domain_found_by(wildcards):
+    if MODE == config_utils.Mode.SEARCH:
+        return rules.domain_aggregate_hits.output.found_by
+    return rules.domain_cluster_accessions.output.found_by
+
+
+rule domain_join_features:
+    input:
+        domain_features=lambda wildcards: checkpoints.domain_prepare_structures.get(
+            **wildcards
+        ).output.features,
+        uniprot=get_domain_uniprot_features,
+        found_by=get_domain_found_by,
+    output:
+        joined=DOMAIN_FEATURES_DIR / "domain_uniprot_features.tsv",
+    conda:
+        "envs/pandas.yml"
+    shell:
+        """
+        python ProteinCartography/join_domain_features.py \
+            --domain-features {input.domain_features} \
+            --uniprot-features {input.uniprot} \
+            --found-by {input.found_by} \
+            --output {output.joined}
+        """
+
+
+rule domain_aggregate_features:
+    input:
+        rules.domain_assess_pdbs.output.pdb_features,
+        rules.domain_foldseek_clustering.output.struclusters_features,
+        rules.domain_leiden_clustering.output.leiden_features,
+        rules.domain_calculate_key_tmscores.output.key_tmscores,
+        rules.domain_join_features.output.joined,
+    output:
+        aggregated_features=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_aggregated_features_domain.tsv",
+    conda:
+        "envs/pandas.yml"
+    shell:
+        """
+        python ProteinCartography/aggregate_features.py \
+            --input {input} \
+            --output {output.aggregated_features} \
+            --features-override-file {FEATURES_OVERRIDE_FILE}
+        """
+
+
+rule domain_plot_interactive:
+    input:
+        tm_scores=rules.domain_dim_reduction.output.all_by_all_tmscores,
+        features=rules.domain_aggregate_features.output.aggregated_features,
+    output:
+        html=FINAL_RESULTS_DIR
+        / (ANALYSIS_NAME + "_aggregated_features_{plotting_mode}_domain.html"),
+    conda:
+        "envs/plotting.yml"
+    params:
+        keyids=lambda wildcards: " ".join(get_query_domain_ids(wildcards)),
+    shell:
+        """
+        python ProteinCartography/plot_interactive.py \
+            --dimensions {input.tm_scores} \
+            --features {input.features} \
+            --output {output.html} \
+            --dimensions-type {wildcards.plotting_mode} \
+            --keyids {params.keyids} \
+            --taxon-focus {TAXON_FOCUS}
+        """
+
+
+rule domain_plot_similarity_leiden:
+    input:
+        tm_scores=rules.domain_foldseek_clustering.output.all_by_all_tmscores,
+        features=rules.domain_leiden_clustering.output.leiden_features,
+    output:
+        tsv=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_leiden_similarity_domain.tsv",
+        html=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_leiden_similarity_domain.html",
+    conda:
+        "envs/plotting.yml"
+    shell:
+        """
+        python ProteinCartography/plot_cluster_similarity.py \
+            --matrix-file {input.tm_scores} \
+            --features-file {input.features} \
+            --features-column LeidenCluster \
+            --output-tsv {output.tsv} \
+            --output-html {output.html}
+        """
+
+
+rule domain_plot_similarity_strucluster:
+    input:
+        tm_scores=rules.domain_foldseek_clustering.output.all_by_all_tmscores,
+        features=rules.domain_foldseek_clustering.output.struclusters_features,
+    output:
+        tsv=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_strucluster_similarity_domain.tsv",
+        html=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_strucluster_similarity_domain.html",
+    conda:
+        "envs/plotting.yml"
+    shell:
+        """
+        python ProteinCartography/plot_cluster_similarity.py \
+            --matrix-file {input.tm_scores} \
+            --features-file {input.features} \
+            --features-column StruCluster \
+            --output-tsv {output.tsv} \
+            --output-html {output.html}
+        """
+
+
+rule domain_plot_semantic_analysis:
+    input:
+        features=rules.domain_aggregate_features.output.aggregated_features,
+    output:
+        pdf=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_semantic_analysis_domain.pdf",
+        html=FINAL_RESULTS_DIR / f"{ANALYSIS_NAME}_semantic_analysis_domain.html",
+    conda:
+        "envs/plotting.yml"
+    shell:
+        """
+        python ProteinCartography/semantic_analysis.py \
+            --features-file {input.features} \
+            --agg-column LeidenCluster \
+            --annot-column 'Protein names' \
+            --output {output.pdf} \
+            --interactive {output.html} \
+            --analysis-name {ANALYSIS_NAME}_domain
+        """
+
+
+rule domain_plot_cluster_distributions:
+    input:
+        features=rules.domain_aggregate_features.output.aggregated_features,
+    output:
+        svg=FINAL_RESULTS_DIR / (ANALYSIS_NAME + "_{domain_id}_distribution_analysis_domain.svg"),
+    conda:
+        "envs/plotting.yml"
+    shell:
+        """
+        python ProteinCartography/plot_cluster_distributions.py \
+            --input {input.features} \
+            --output {output.svg} \
+            --keyid {wildcards.domain_id}
+        """

--- a/config.yml
+++ b/config.yml
@@ -83,6 +83,16 @@ max_structures: 5000
 min_length: 0
 max_length: 0
 
+# Parallel domain map. The protein search and map always run unchanged.
+#   auto - if a query has two or more TED/user domains, also search each query domain
+#          and emit *_domain HTML maps. Single-domain queries skip this path entirely.
+#   off  - never run the domain DAG.
+domain_map: "auto"
+# Spans shorter than this (residues) are dropped before the multi-domain count.
+min_domain_length: 30
+# Optional TSV in input_dir: parent_protid and chopping (or start and end). Overrides TED.
+user_domains_file: ""
+
 
 # ------------------------------------------------------------------------------------------------
 # Cluster-mode settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,7 @@ exclude = 'dev'
 # Scripts live in ProteinCartography/ and import as top-level modules
 # (import blast_utils, not ProteinCartography.blast_utils).
 pythonpath = ["ProteinCartography"]
+addopts = ["-m", "not live_ted"]
+markers = [
+    "live_ted: hits the live TED HTTP API (not run in default CI)",
+]

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,10 @@ setup(
     license="MIT",
     description="Builds maps of protein space from structures.",
     scripts=[
+        "ProteinCartography/aggregate_domain_hits.py",
         "ProteinCartography/aggregate_features.py",
         "ProteinCartography/aggregate_hits.py",
+        "ProteinCartography/assign_domains.py",
         "ProteinCartography/dim_reduction.py",
         "ProteinCartography/esmfold_apiquery.py",
         "ProteinCartography/extract_blast_hits.py",
@@ -20,6 +22,7 @@ setup(
         "ProteinCartography/foldseek_apiquery.py",
         "ProteinCartography/foldseek_clustering.py",
         "ProteinCartography/get_source_of_hits.py",
+        "ProteinCartography/join_domain_features.py",
         "ProteinCartography/leiden_clustering.py",
         "ProteinCartography/map_refseq_ids.py",
         "ProteinCartography/plot_interactive.py",


### PR DESCRIPTION
## Summary
- Protein search/cluster still always run with the same inputs, directories, and `final_results` filenames.
- If a query has two or more TED (or user-TSV) domains after `min_domain_length`, a separate DAG (`Snakefile_domain`) searches each cropped query domain and writes `*_domain` maps. Single-domain queries skip that path (`domain_map: auto|off`).
- Domain HTML adds parent / CATH / chopping overlays; TM-score layers are vs query domains only.

## Test plan
- [ ] CI `make test` (mocked search + cluster pipeline, plus new domain unit/integration tests)
- [x] Domain unit tests: 36 passed locally (`test_domain_utils`, `test_assign_domains`, `test_aggregate_domain_hits`, `test_join_domain_features`)
- [x] Live lysozyme `P00698` (1 TED domain): gate **off**, protein map only, no `*_domain.html`
- [x] Live actin `P60709` (3 TED domains): protein + domain maps
- [x] Live albumin `P02768` (5 TED domains): protein + domain maps

`pytest -m live_ted` is opt-in (TED schema check for P00698 chopping `22-141`).


Made with [Cursor](https://cursor.com)